### PR TITLE
Add PreviewController (step 1.4)

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -103,7 +103,7 @@ Unit tests in `test/devices/device_database_test.dart` covering `forPlatform`,
 `findById` (found and not-found), that `defaultProfile` is in `all`, and that every profile
 in `all` has a non-null `cutout` (i.e. no profile accidentally omits the field).
 
-### Step 1.4 — PreviewController
+### Step 1.4 — PreviewController [done]
 
 Create `lib/src/preview_controller.dart`.
 

--- a/lib/src/preview_controller.dart
+++ b/lib/src/preview_controller.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/foundation.dart' show ChangeNotifier;
+import 'package:flutter/painting.dart' show EdgeInsets, Size;
+
+import 'devices/device_database.dart';
+import 'devices/device_profile.dart';
+
+/// The single source of truth for the active device preview state.
+///
+/// Holds the active [DeviceProfile], screen [orientation], and toolbar
+/// visibility. Widgets read state via [ListenableBuilder] or
+/// [AnimatedBuilder]; the binding layer reacts to changes by re-reporting
+/// spoofed metrics to the framework.
+class PreviewController extends ChangeNotifier {
+  DeviceProfile _activeProfile = DeviceDatabase.defaultProfile;
+  DeviceOrientation _orientation = DeviceOrientation.portrait;
+  bool _toolbarVisible = true;
+
+  /// The currently active device profile.
+  DeviceProfile get activeProfile => _activeProfile;
+
+  /// The current screen orientation.
+  DeviceOrientation get orientation => _orientation;
+
+  /// Whether the preview toolbar is visible.
+  bool get toolbarVisible => _toolbarVisible;
+
+  /// The emulated logical screen size for the current profile and orientation.
+  Size get emulatedLogicalSize =>
+      _activeProfile.logicalSizeForOrientation(_orientation);
+
+  /// The emulated safe area insets for the current profile and orientation.
+  EdgeInsets get emulatedSafeArea =>
+      _activeProfile.safeAreaForOrientation(_orientation);
+
+  /// Switches to [profile] and notifies listeners.
+  void setProfile(DeviceProfile profile) {
+    if (_activeProfile == profile) return;
+    _activeProfile = profile;
+    notifyListeners();
+  }
+
+  /// Toggles between portrait and landscape and notifies listeners.
+  void toggleOrientation() {
+    _orientation = switch (_orientation) {
+      DeviceOrientation.portrait => DeviceOrientation.landscape,
+      DeviceOrientation.landscape => DeviceOrientation.portrait,
+    };
+    notifyListeners();
+  }
+
+  /// Toggles toolbar visibility and notifies listeners.
+  void toggleToolbar() {
+    _toolbarVisible = !_toolbarVisible;
+    notifyListeners();
+  }
+}

--- a/test/preview_controller_test.dart
+++ b/test/preview_controller_test.dart
@@ -1,0 +1,143 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:bezel/src/devices/device_database.dart';
+import 'package:bezel/src/devices/device_profile.dart';
+import 'package:bezel/src/preview_controller.dart';
+
+void main() {
+  late PreviewController controller;
+
+  setUp(() {
+    controller = PreviewController();
+  });
+
+  tearDown(() {
+    controller.dispose();
+  });
+
+  group('initial state', () {
+    test('activeProfile is the default profile', () {
+      expect(controller.activeProfile, DeviceDatabase.defaultProfile);
+    });
+
+    test('orientation is portrait', () {
+      expect(controller.orientation, DeviceOrientation.portrait);
+    });
+
+    test('toolbarVisible is true', () {
+      expect(controller.toolbarVisible, isTrue);
+    });
+  });
+
+  group('setProfile', () {
+    test('updates activeProfile', () {
+      final target = DeviceDatabase.all.firstWhere(
+        (p) => p.id != DeviceDatabase.defaultProfile.id,
+      );
+      controller.setProfile(target);
+      expect(controller.activeProfile, target);
+    });
+
+    test('notifies listeners', () {
+      var notified = false;
+      controller.addListener(() => notified = true);
+
+      final target = DeviceDatabase.all.firstWhere(
+        (p) => p.id != DeviceDatabase.defaultProfile.id,
+      );
+      controller.setProfile(target);
+
+      expect(notified, isTrue);
+    });
+
+    test('does not notify when profile is unchanged', () {
+      var count = 0;
+      controller.addListener(() => count++);
+      controller.setProfile(controller.activeProfile);
+      expect(count, 0);
+    });
+  });
+
+  group('toggleOrientation', () {
+    test('switches portrait to landscape', () {
+      expect(controller.orientation, DeviceOrientation.portrait);
+      controller.toggleOrientation();
+      expect(controller.orientation, DeviceOrientation.landscape);
+    });
+
+    test('switches landscape back to portrait', () {
+      controller.toggleOrientation();
+      controller.toggleOrientation();
+      expect(controller.orientation, DeviceOrientation.portrait);
+    });
+
+    test('notifies listeners', () {
+      var notified = false;
+      controller.addListener(() => notified = true);
+      controller.toggleOrientation();
+      expect(notified, isTrue);
+    });
+  });
+
+  group('toggleToolbar', () {
+    test('hides the toolbar', () {
+      controller.toggleToolbar();
+      expect(controller.toolbarVisible, isFalse);
+    });
+
+    test('shows the toolbar again', () {
+      controller.toggleToolbar();
+      controller.toggleToolbar();
+      expect(controller.toolbarVisible, isTrue);
+    });
+
+    test('notifies listeners', () {
+      var notified = false;
+      controller.addListener(() => notified = true);
+      controller.toggleToolbar();
+      expect(notified, isTrue);
+    });
+  });
+
+  group('emulatedLogicalSize', () {
+    test('matches portrait logical size in portrait orientation', () {
+      expect(
+        controller.emulatedLogicalSize,
+        controller.activeProfile.logicalSizeForOrientation(
+          DeviceOrientation.portrait,
+        ),
+      );
+    });
+
+    test('matches landscape logical size after toggleOrientation', () {
+      controller.toggleOrientation();
+      expect(
+        controller.emulatedLogicalSize,
+        controller.activeProfile.logicalSizeForOrientation(
+          DeviceOrientation.landscape,
+        ),
+      );
+    });
+  });
+
+  group('emulatedSafeArea', () {
+    test('matches portrait safe area in portrait orientation', () {
+      expect(
+        controller.emulatedSafeArea,
+        controller.activeProfile.safeAreaForOrientation(
+          DeviceOrientation.portrait,
+        ),
+      );
+    });
+
+    test('matches landscape safe area after toggleOrientation', () {
+      controller.toggleOrientation();
+      expect(
+        controller.emulatedSafeArea,
+        controller.activeProfile.safeAreaForOrientation(
+          DeviceOrientation.landscape,
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Adds the central state object for the preview session.

- `PreviewController extends ChangeNotifier` — holds active profile, orientation, and toolbar visibility
- `setProfile` is a no-op when called with the current profile (avoids spurious rebuilds)
- `emulatedLogicalSize` and `emulatedSafeArea` are derived getters that delegate to the active profile
- 16 unit tests covering initial state, all mutations, notification firing, and both derived values across orientations
- Marks step 1.4 as done in `docs/PLAN.md`