### PR TITLE
Add PreviewBinding and wire up Bezel entry point (step 1.7)

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -163,7 +163,7 @@ the preview view just wraps the real one, it doesn't replace it.
 
 No unit tests needed at this layer — integration is tested via the binding step.
 
-### Step 1.7 — PreviewBinding
+### Step 1.7 — PreviewBinding [done]
 
 Create `lib/src/binding/preview_binding.dart`.
 

--- a/lib/bezel.dart
+++ b/lib/bezel.dart
@@ -11,7 +11,8 @@
 /// ```
 library;
 
-// TODO: export src
+import 'src/preview_controller.dart';
+import 'src/preview_real.dart' if (dart.library.html) 'src/preview_stub.dart';
 
 /// Entry point for the bezel package.
 ///
@@ -22,14 +23,24 @@ abstract final class Bezel {
   /// Activates the bezel preview in debug mode.
   ///
   /// Safe to call in release/profile builds — the assert ensures the
-  /// implementation is unreachable and tree-shaken out.
+  /// implementation is unreachable and tree-shaken out entirely.
   static void ensureInitialized() {
     assert(() {
-      _debugEnsureInitialized();
+      debugEnsureInitialized();
       return true;
     }());
   }
-}
 
-// Stub implementation until Step 1.7 wires up the real binding.
-void _debugEnsureInitialized() {}
+  /// The active [PreviewController] for the current session.
+  ///
+  /// Returns `null` in release/profile builds or before [ensureInitialized]
+  /// has been called.
+  static PreviewController? get controller {
+    PreviewController? result;
+    assert(() {
+      result = debugController;
+      return true;
+    }());
+    return result;
+  }
+}

--- a/lib/src/binding/preview_binding.dart
+++ b/lib/src/binding/preview_binding.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/widgets.dart' show WidgetsFlutterBinding;
+
+import '../preview_controller.dart';
+import 'preview_platform_dispatcher.dart';
+
+/// A custom binding that installs [PreviewPlatformDispatcher], causing the
+/// framework to receive spoofed device metrics for the active [DeviceProfile].
+///
+/// Installed by calling [ensureInitialized] before [runApp]. In release and
+/// profile builds the call is inside an `assert`, so the binding — and all
+/// preview code — is tree-shaken out entirely.
+class PreviewBinding extends WidgetsFlutterBinding {
+  PreviewBinding._();
+
+  static PreviewBinding? _instance;
+
+  final PreviewController _controller = PreviewController();
+
+  // Mirrors the pattern used by TestWidgetsFlutterBinding.
+  @override
+  PreviewPlatformDispatcher get platformDispatcher => _previewDispatcher;
+
+  late final PreviewPlatformDispatcher _previewDispatcher =
+      PreviewPlatformDispatcher(super.platformDispatcher, _controller);
+
+  /// The shared [PreviewController] for this session.
+  ///
+  /// Throws if [ensureInitialized] has not yet been called.
+  static PreviewController get controller {
+    assert(
+      _instance != null,
+      'PreviewBinding.ensureInitialized() must be called before accessing controller.',
+    );
+    return _instance!._controller;
+  }
+
+  /// Initialises the preview binding.
+  ///
+  /// Follows the same pattern as [WidgetsFlutterBinding.ensureInitialized].
+  /// Safe to call multiple times — subsequent calls return the existing
+  /// instance.
+  static PreviewBinding ensureInitialized() {
+    _instance ??= PreviewBinding._();
+    return _instance!;
+  }
+}

--- a/lib/src/preview_real.dart
+++ b/lib/src/preview_real.dart
@@ -1,0 +1,9 @@
+import 'binding/preview_binding.dart';
+import 'preview_controller.dart';
+
+/// Initialises the preview binding. Called only in debug mode via `assert`.
+void debugEnsureInitialized() => PreviewBinding.ensureInitialized();
+
+/// Returns the active [PreviewController], or `null` if the binding has not
+/// been initialised.
+PreviewController? get debugController => PreviewBinding.controller;

--- a/lib/src/preview_stub.dart
+++ b/lib/src/preview_stub.dart
@@ -1,0 +1,7 @@
+import 'preview_controller.dart';
+
+/// No-op on web — the preview tool does not support Flutter Web.
+void debugEnsureInitialized() {}
+
+/// Always `null` on web.
+PreviewController? get debugController => null;


### PR DESCRIPTION
Completes Phase 1 — the full binding layer is now wired end-to-end.

- `PreviewBinding extends WidgetsFlutterBinding` — overrides `platformDispatcher` to return `PreviewPlatformDispatcher`, following the same pattern as `TestWidgetsFlutterBinding`; exposes `static controller` and `ensureInitialized()`
- `preview_real.dart` / `preview_stub.dart` — real and no-op implementations of `debugEnsureInitialized()` and `debugController`; selected at compile time via a conditional import on `dart.library.html`
- `bezel.dart` — updated to use the conditional import (not export, so helpers stay private); `Bezel.ensureInitialized()` and `Bezel.controller` wrap calls inside `assert()` for release-mode tree-shaking

The initial write used `export` instead of `import` for the conditional file, and `dart:ui` / `WidgetsBinding` imports that weren't needed — all caught by the post-write hook before the first analyzer run.