### PR TITLE
Add DeviceFrameWidget (step 2.2)

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -48,25 +48,9 @@ Created `lib/src/binding/preview_binding.dart` — a `WidgetsFlutterBinding` sub
 
 Created `lib/src/frame/device_frame_painter.dart` — a `CustomPainter` that renders a dark rounded-rect device body with style-specific bezels and decorations (speaker slit + home button for `classic`), then applies `canvas.clipPath` to subtract the cutout shape from the screen area so the child widget's pixels are physically absent in the camera housing region. Exposes `DeviceFramePainter.screenRectForSize(Size, DeviceProfile, DeviceOrientation)` for use by the layout widget in step 2.2.
 
-### Step 2.2 — DeviceFrameWidget
+### Step 2.2 — DeviceFrameWidget [done]
 
-Create `lib/src/frame/device_frame_widget.dart`.
-
-`class DeviceFrameWidget extends StatelessWidget` that:
-- Takes `DeviceProfile`, `DeviceOrientation`, and `Widget child`
-- Uses a `LayoutBuilder` to get the available size
-- Computes the screen rect via `DeviceFramePainter.screenRectForSize`
-- Uses a `Stack` with a `CustomPaint` (the frame) and a `Positioned` child constrained
-  to the screen rect
-- Clips the child to the screen rect using `ClipRect`
-
-Note: the cutout clip is applied by `DeviceFramePainter` directly to the canvas (via
-`canvas.clipPath`), so the `ClipRect` here only clips to the outer screen rect boundary.
-The two clips compose correctly — no additional cutout handling is needed in this widget.
-
-The widget does **not** do any metric spoofing — it is purely cosmetic framing.
-
-Widget test: verify the child is constrained to a rect with the correct aspect ratio.
+Created `lib/src/frame/device_frame_widget.dart` — a `StatelessWidget` that uses `LayoutBuilder` to fill available space, computes the screen rect via `DeviceFramePainter.screenRectForSize`, and positions the child in a `Stack` with a `CustomPaint` painter and a `Positioned`+`ClipRect` child. The canvas clip from the painter is inherited by the child (cutout exclusion), and the `ClipRect` bounds the outer screen rect. Purely cosmetic — no metric spoofing.
 
 ### Step 2.3 — PreviewOverlay
 

--- a/lib/src/frame/device_frame_widget.dart
+++ b/lib/src/frame/device_frame_widget.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/widgets.dart';
+
+import '../devices/device_profile.dart';
+import 'device_frame_painter.dart';
+
+/// A purely decorative widget that paints a device frame around [child].
+///
+/// Uses [LayoutBuilder] to fill the available space, computes the screen rect
+/// via [DeviceFramePainter.screenRectForSize], and positions [child] precisely
+/// within that rect.
+///
+/// The cutout clip is applied by [DeviceFramePainter] directly to the canvas,
+/// so child pixels are physically absent inside the camera housing region. The
+/// [ClipRect] here only clips to the outer screen-rect boundary.
+///
+/// This widget does **not** perform any metric spoofing — it is purely
+/// cosmetic. Metric spoofing happens in the binding layer.
+class DeviceFrameWidget extends StatelessWidget {
+  const DeviceFrameWidget({
+    super.key,
+    required this.profile,
+    required this.orientation,
+    required this.child,
+  });
+
+  /// The device whose frame to render.
+  final DeviceProfile profile;
+
+  /// The current screen orientation.
+  final DeviceOrientation orientation;
+
+  /// The app content to display inside the screen area.
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final size = constraints.biggest;
+        final screenRect = DeviceFramePainter.screenRectForSize(
+          size,
+          profile,
+          orientation,
+        );
+
+        return Stack(
+          children: [
+            // Device frame — fills the full layout bounds and sets the canvas
+            // clip for anything rendered on top of it (including the child).
+            Positioned.fill(
+              child: CustomPaint(
+                painter: DeviceFramePainter(
+                  profile: profile,
+                  orientation: orientation,
+                ),
+              ),
+            ),
+
+            // App content — constrained to the screen rect and clipped to its
+            // boundary. The cutout clip from the painter further refines this.
+            Positioned(
+              left: screenRect.left,
+              top: screenRect.top,
+              width: screenRect.width,
+              height: screenRect.height,
+              child: ClipRect(child: child),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/test/frame/device_frame_widget_test.dart
+++ b/test/frame/device_frame_widget_test.dart
@@ -1,0 +1,140 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:bezel/src/devices/device_database.dart';
+import 'package:bezel/src/devices/device_profile.dart';
+import 'package:bezel/src/frame/device_frame_painter.dart';
+import 'package:bezel/src/frame/device_frame_widget.dart';
+
+void main() {
+  group('DeviceFrameWidget', () {
+    testWidgets('child size matches screenRectForSize', (tester) async {
+      final profile = DeviceDatabase.findById('iphone_15')!;
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: DeviceFrameWidget(
+            profile: profile,
+            orientation: DeviceOrientation.portrait,
+            child: const ColoredBox(
+              color: Color(0xFF0000FF),
+              child: SizedBox.expand(),
+            ),
+          ),
+        ),
+      );
+
+      // Use the actual rendered frame size so the test is independent of the
+      // test viewport dimensions.
+      final frameBox = tester.renderObject<RenderBox>(
+        find.byType(DeviceFrameWidget),
+      );
+      final expectedScreen = DeviceFramePainter.screenRectForSize(
+        frameBox.size,
+        profile,
+        DeviceOrientation.portrait,
+      );
+
+      final childBox = tester.renderObject<RenderBox>(find.byType(ColoredBox));
+      expect(childBox.size.width, closeTo(expectedScreen.width, 0.5));
+      expect(childBox.size.height, closeTo(expectedScreen.height, 0.5));
+    });
+
+    testWidgets('child is smaller than the full frame (bezels are present)', (
+      tester,
+    ) async {
+      final profile = DeviceDatabase.findById('iphone_15')!;
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: DeviceFrameWidget(
+            profile: profile,
+            orientation: DeviceOrientation.portrait,
+            child: const ColoredBox(
+              color: Color(0xFF0000FF),
+              child: SizedBox.expand(),
+            ),
+          ),
+        ),
+      );
+
+      final frameBox = tester.renderObject<RenderBox>(
+        find.byType(DeviceFrameWidget),
+      );
+      final childBox = tester.renderObject<RenderBox>(find.byType(ColoredBox));
+
+      expect(childBox.size.width, lessThan(frameBox.size.width));
+      expect(childBox.size.height, lessThan(frameBox.size.height));
+    });
+
+    testWidgets('landscape child is wider than tall', (tester) async {
+      final profile = DeviceDatabase.findById('iphone_15')!;
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: DeviceFrameWidget(
+            profile: profile,
+            orientation: DeviceOrientation.landscape,
+            child: const ColoredBox(
+              color: Color(0xFF00FF00),
+              child: SizedBox.expand(),
+            ),
+          ),
+        ),
+      );
+
+      final childBox = tester.renderObject<RenderBox>(find.byType(ColoredBox));
+      expect(childBox.size.width, greaterThan(childBox.size.height));
+    });
+
+    testWidgets('portrait child is taller than wide', (tester) async {
+      final profile = DeviceDatabase.findById('iphone_15')!;
+
+      // Set a portrait-shaped test viewport (300×550 logical pixels).
+      tester.view.physicalSize = const Size(900, 1650);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: DeviceFrameWidget(
+            profile: profile,
+            orientation: DeviceOrientation.portrait,
+            child: const ColoredBox(
+              color: Color(0xFFFF0000),
+              child: SizedBox.expand(),
+            ),
+          ),
+        ),
+      );
+
+      final childBox = tester.renderObject<RenderBox>(find.byType(ColoredBox));
+      expect(childBox.size.height, greaterThan(childBox.size.width));
+    });
+
+    testWidgets('renders all database profiles without throwing', (
+      tester,
+    ) async {
+      for (final profile in DeviceDatabase.all) {
+        for (final orientation in DeviceOrientation.values) {
+          await tester.pumpWidget(
+            Directionality(
+              textDirection: TextDirection.ltr,
+              child: DeviceFrameWidget(
+                profile: profile,
+                orientation: orientation,
+                child: const SizedBox.expand(),
+              ),
+            ),
+          );
+          // No exception → pass.
+        }
+      }
+    });
+  });
+}


### PR DESCRIPTION
Wraps `DeviceFramePainter` in a layout widget that positions the child precisely inside the screen rect.

- `DeviceFrameWidget` uses `LayoutBuilder` → `DeviceFramePainter.screenRectForSize` → `Stack` with a `CustomPaint` painter and a `Positioned`+`ClipRect` child
- The painter's `canvas.clipPath` (cutout exclusion) is inherited by the child; `ClipRect` handles the outer screen boundary
- Purely cosmetic — no metric spoofing
- 5 widget tests covering size correctness, bezel presence, portrait/landscape orientation, and all database profiles