### PR TITLE
Add device picker popover (step 2.6)

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -88,16 +88,19 @@ because the toolbar sits above the user's widget tree and has no `Overlay` ances
 changes. `passthroughMode` in `PreviewOverlay` bypasses the frame entirely, rendering the
 raw child widget instead.
 
-### Step 2.6 — Device picker popover
+### Step 2.6 — Device picker popover [done]
 
-Create `lib/src/ui/device_picker.dart`.
+Created `lib/src/ui/device_picker.dart` — a `StatelessWidget` rendered directly in the
+overlay `Stack` (via `Positioned.fill`) rather than through `showDialog`, because the toolbar
+sits above the user's `MaterialApp` and has no `Navigator`/`Overlay` ancestor. Devices are
+grouped under "iOS" and "Android" section headers using a `SingleChildScrollView` + `Column`
+(eager rendering) rather than `ListView` (lazy rendering). The active profile is checkmarked.
+Tapping an item calls `controller.setProfile` and `controller.toggleDevicePicker`. Tapping
+outside the card dismisses via `HitTestBehavior.opaque` on the outer `GestureDetector`.
 
-`class DevicePicker` — a static method `show(BuildContext context, PreviewController
-controller)` that shows a `showDialog`-based popover (or `showMenu`) listing all devices
-from `DeviceDatabase.all`, grouped under "iOS" and "Android" section headers.
-
-Each item shows the device name. The active device is checkmarked. Tapping an item calls
-`controller.setProfile(profile)` and closes the picker.
+Added `devicePickerVisible` + `toggleDevicePicker()` to `PreviewController`. Wired the
+device name button in `PreviewToolbar` to call `toggleDevicePicker`. Updated `PreviewOverlay`
+to show `DevicePicker` as a `Positioned.fill` child when `devicePickerVisible` is true.
 
 ---
 

--- a/lib/src/preview_controller.dart
+++ b/lib/src/preview_controller.dart
@@ -30,6 +30,7 @@ class PreviewController extends ChangeNotifier {
   DeviceOrientation _orientation = DeviceOrientation.portrait;
   bool _toolbarVisible = true;
   bool _passthroughMode = false;
+  bool _devicePickerVisible = false;
 
   /// The currently active device profile.
   DeviceProfile get activeProfile => _activeProfile;
@@ -45,6 +46,9 @@ class PreviewController extends ChangeNotifier {
   /// When true, the device frame is hidden and the app is shown at its natural
   /// window size. Toggling back to false re-activates the preview.
   bool get passthroughMode => _passthroughMode;
+
+  /// Whether the device picker is currently open.
+  bool get devicePickerVisible => _devicePickerVisible;
 
   /// The emulated logical screen size for the current profile and orientation.
   Size get emulatedLogicalSize =>
@@ -87,6 +91,12 @@ class PreviewController extends ChangeNotifier {
   /// Toggles passthrough mode and notifies listeners.
   void togglePassthrough() {
     _passthroughMode = !_passthroughMode;
+    notifyListeners();
+  }
+
+  /// Toggles the device picker visibility and notifies listeners.
+  void toggleDevicePicker() {
+    _devicePickerVisible = !_devicePickerVisible;
     notifyListeners();
   }
 }

--- a/lib/src/ui/device_picker.dart
+++ b/lib/src/ui/device_picker.dart
@@ -1,0 +1,152 @@
+import 'package:flutter/material.dart';
+
+import '../devices/device_database.dart';
+import '../devices/device_profile.dart';
+import '../preview_controller.dart';
+
+/// Foreground colour for section headers and items.
+const _kForegroundColor = Color(0xFFFFFFFF);
+
+/// Muted colour used for section header labels.
+const _kHeaderColor = Color(0x99FFFFFF);
+
+/// Background colour of the picker card.
+const _kCardColor = Color(0xE61A1A1A);
+
+/// A floating device-picker card rendered directly in the preview overlay's
+/// [Stack].
+///
+/// Rather than using [showDialog] (which requires a [Navigator]/[Overlay]
+/// ancestor that the toolbar does not have), [DevicePicker] is a plain widget
+/// embedded in the overlay's stack and toggled via [PreviewController].
+///
+/// Usage in the overlay [Stack]:
+/// ```dart
+/// if (controller.devicePickerVisible)
+///   DevicePicker(controller: controller),
+/// ```
+class DevicePicker extends StatelessWidget {
+  const DevicePicker({super.key, required this.controller});
+
+  final PreviewController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final iOS = DeviceDatabase.forPlatform(DevicePlatform.iOS);
+    final android = DeviceDatabase.forPlatform(DevicePlatform.android);
+
+    return GestureDetector(
+      // Tapping outside the card closes the picker.
+      // HitTestBehavior.opaque makes the detector fill its constraints even
+      // though its child (Center → card) is smaller.
+      behavior: HitTestBehavior.opaque,
+      onTap: controller.toggleDevicePicker,
+      child: Center(
+        child: GestureDetector(
+          // Absorb taps inside the card so they don't propagate to the
+          // outer dismissal layer.
+          onTap: () {},
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 280, maxHeight: 480),
+            child: Material(
+              color: _kCardColor,
+              borderRadius: const BorderRadius.all(Radius.circular(12)),
+              child: ClipRRect(
+                borderRadius: const BorderRadius.all(Radius.circular(12)),
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.symmetric(vertical: 8),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      const _SectionHeader(label: 'iOS'),
+                      for (final profile in iOS)
+                        _DeviceItem(
+                          profile: profile,
+                          isActive: profile.id == controller.activeProfile.id,
+                          onTap: () {
+                            controller.setProfile(profile);
+                            controller.toggleDevicePicker();
+                          },
+                        ),
+                      const _SectionHeader(label: 'Android'),
+                      for (final profile in android)
+                        _DeviceItem(
+                          profile: profile,
+                          isActive: profile.id == controller.activeProfile.id,
+                          onTap: () {
+                            controller.setProfile(profile);
+                            controller.toggleDevicePicker();
+                          },
+                        ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ── Section header ────────────────────────────────────────────────────────────
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+      child: Text(
+        label,
+        style: const TextStyle(
+          color: _kHeaderColor,
+          fontSize: 11,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0.8,
+        ),
+      ),
+    );
+  }
+}
+
+// ── Device item ───────────────────────────────────────────────────────────────
+
+class _DeviceItem extends StatelessWidget {
+  const _DeviceItem({
+    required this.profile,
+    required this.isActive,
+    required this.onTap,
+  });
+
+  final DeviceProfile profile;
+  final bool isActive;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+        child: Row(
+          children: [
+            Expanded(
+              child: Text(
+                profile.name,
+                style: const TextStyle(color: _kForegroundColor, fontSize: 14),
+              ),
+            ),
+            if (isActive)
+              const Icon(Icons.check, color: _kForegroundColor, size: 16),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/ui/preview_overlay.dart
+++ b/lib/src/ui/preview_overlay.dart
@@ -5,6 +5,7 @@ import 'package:flutter/widgets.dart';
 
 import '../frame/device_frame_widget.dart';
 import '../preview_controller.dart';
+import 'device_picker.dart';
 import 'preview_toolbar.dart';
 
 /// Background colour shown behind the device frame.
@@ -86,6 +87,12 @@ class PreviewOverlay extends StatelessWidget {
                             alignment: Alignment.topCenter,
                             child: PreviewToolbar(controller: controller),
                           ),
+                        ),
+
+                      // Device picker — covers the full overlay when open.
+                      if (controller.devicePickerVisible)
+                        Positioned.fill(
+                          child: DevicePicker(controller: controller),
                         ),
                     ],
                   ),

--- a/lib/src/ui/preview_toolbar.dart
+++ b/lib/src/ui/preview_toolbar.dart
@@ -65,9 +65,7 @@ class _DeviceNameButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return InkWell(
       borderRadius: _kPillRadius,
-      onTap: () {
-        // Step 2.6 will replace this with the real device picker.
-      },
+      onTap: controller.toggleDevicePicker,
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 8.0),
         child: ConstrainedBox(

--- a/test/preview_controller_test.dart
+++ b/test/preview_controller_test.dart
@@ -123,6 +123,30 @@ void main() {
     });
   });
 
+  group('toggleDevicePicker', () {
+    test('devicePickerVisible starts false', () {
+      expect(controller.devicePickerVisible, isFalse);
+    });
+
+    test('opens the picker', () {
+      controller.toggleDevicePicker();
+      expect(controller.devicePickerVisible, isTrue);
+    });
+
+    test('closes the picker on second call', () {
+      controller.toggleDevicePicker();
+      controller.toggleDevicePicker();
+      expect(controller.devicePickerVisible, isFalse);
+    });
+
+    test('notifies listeners', () {
+      var notified = false;
+      controller.addListener(() => notified = true);
+      controller.toggleDevicePicker();
+      expect(notified, isTrue);
+    });
+  });
+
   group('emulatedLogicalSize', () {
     test('matches portrait logical size in portrait orientation', () {
       expect(

--- a/test/ui/device_picker_test.dart
+++ b/test/ui/device_picker_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:bezel/src/devices/device_database.dart';
+import 'package:bezel/src/devices/device_profile.dart';
+import 'package:bezel/src/preview_controller.dart';
+import 'package:bezel/src/ui/device_picker.dart';
+
+/// Wraps [child] with the ancestors required by Material-level widgets.
+Widget _wrap(Widget child) {
+  return MaterialApp(home: Scaffold(body: child));
+}
+
+void main() {
+  late PreviewController controller;
+
+  setUp(() => controller = PreviewController());
+  tearDown(() => controller.dispose());
+
+  group('DevicePicker', () {
+    testWidgets('lists all iOS devices', (tester) async {
+      await tester.pumpWidget(_wrap(DevicePicker(controller: controller)));
+
+      for (final profile in DeviceDatabase.forPlatform(DevicePlatform.iOS)) {
+        expect(find.text(profile.name), findsOneWidget);
+      }
+    });
+
+    testWidgets('lists all Android devices', (tester) async {
+      await tester.pumpWidget(_wrap(DevicePicker(controller: controller)));
+
+      for (final profile in DeviceDatabase.forPlatform(
+        DevicePlatform.android,
+      )) {
+        expect(find.text(profile.name), findsOneWidget);
+      }
+    });
+
+    testWidgets('shows a check next to the active device', (tester) async {
+      await tester.pumpWidget(_wrap(DevicePicker(controller: controller)));
+
+      // One check icon — for the currently active device.
+      expect(find.byIcon(Icons.check), findsOneWidget);
+    });
+
+    testWidgets('active device check moves after setProfile', (tester) async {
+      final next = DeviceDatabase.all.firstWhere(
+        (p) => p.id != controller.activeProfile.id,
+      );
+      controller.setProfile(next);
+
+      await tester.pumpWidget(_wrap(DevicePicker(controller: controller)));
+
+      // Still exactly one check, next to the new active device.
+      expect(find.byIcon(Icons.check), findsOneWidget);
+    });
+
+    testWidgets('tapping a device calls setProfile and closes picker', (
+      tester,
+    ) async {
+      controller.toggleDevicePicker();
+      await tester.pumpWidget(_wrap(DevicePicker(controller: controller)));
+
+      final target = DeviceDatabase.all.firstWhere(
+        (p) => p.id != controller.activeProfile.id,
+      );
+
+      await tester.tap(find.text(target.name));
+
+      expect(controller.activeProfile, target);
+      expect(controller.devicePickerVisible, isFalse);
+    });
+
+    testWidgets('tapping outside the card closes the picker', (tester) async {
+      controller.toggleDevicePicker();
+      await tester.pumpWidget(_wrap(DevicePicker(controller: controller)));
+
+      expect(controller.devicePickerVisible, isTrue);
+
+      // Tap in the top-left corner, outside the centred card.
+      await tester.tapAt(const Offset(4, 4));
+
+      expect(controller.devicePickerVisible, isFalse);
+    });
+  });
+}

--- a/test/ui/preview_overlay_test.dart
+++ b/test/ui/preview_overlay_test.dart
@@ -5,6 +5,7 @@ import 'package:bezel/src/devices/device_database.dart';
 import 'package:bezel/src/devices/device_profile.dart';
 import 'package:bezel/src/frame/device_frame_widget.dart';
 import 'package:bezel/src/preview_controller.dart';
+import 'package:bezel/src/ui/device_picker.dart';
 import 'package:bezel/src/ui/preview_overlay.dart';
 import 'package:bezel/src/ui/preview_toolbar.dart';
 
@@ -166,6 +167,38 @@ void main() {
 
       // In passthrough mode the overlay renders just the raw child — no toolbar.
       expect(find.byType(PreviewToolbar), findsNothing);
+    });
+
+    testWidgets('DevicePicker absent by default', (tester) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: PreviewOverlay(
+            controller: controller,
+            child: const SizedBox.expand(),
+          ),
+        ),
+      );
+
+      expect(find.byType(DevicePicker), findsNothing);
+    });
+
+    testWidgets('DevicePicker shown when devicePickerVisible is true', (
+      tester,
+    ) async {
+      controller.toggleDevicePicker();
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: PreviewOverlay(
+            controller: controller,
+            child: const SizedBox.expand(),
+          ),
+        ),
+      );
+
+      expect(find.byType(DevicePicker), findsOneWidget);
     });
   });
 


### PR DESCRIPTION
Implements step 2.6 — the device picker that opens when tapping the device name in the toolbar.

Branches from step 2.5 (`step_2.5_preview_toolbar`) since that PR hasn't landed on main yet.

- `DevicePicker`: full-screen overlay card with iOS/Android sections, checkmark on the active device, and tap-outside dismissal; rendered directly in the overlay `Stack` as `Positioned.fill` rather than via `showDialog` (no `Navigator`/`Overlay` ancestor above `MaterialApp`)
- `PreviewController`: adds `devicePickerVisible` + `toggleDevicePicker()`
- `PreviewToolbar`: device name button now calls `toggleDevicePicker`
- `PreviewOverlay`: shows `DevicePicker` when `devicePickerVisible` is true

Design notes: uses `SingleChildScrollView`+`Column` over `ListView` for eager item rendering; uses `HitTestBehavior.opaque` on the outer `GestureDetector` so tapping outside always dismisses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)