### PR TITLE
Add keyboard shortcuts (step 3.1)

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -106,17 +106,14 @@ to show `DevicePicker` as a `Positioned.fill` child when `devicePickerVisible` i
 
 ## Phase 3 — Polish and Power Features
 
-### Step 3.1 — Keyboard shortcuts
+### Step 3.1 — Keyboard shortcuts [done]
 
-Create `lib/src/ui/preview_shortcuts.dart`.
-
-Wrap the `PreviewOverlay` content in a `Shortcuts` + `Actions` widget pair:
-- `Ctrl+\` / `Cmd+\` → `controller.toggleToolbar()`
-- `Ctrl+R` / `Cmd+R` → `WidgetsBinding.instance.reassembleApplication()`
-- `Ctrl+L` / `Cmd+L` → `controller.toggleOrientation()`
-
-Use `SingleActivator` with `meta` on macOS and `control` on other platforms, detected via
-`defaultTargetPlatform`.
+Created `lib/src/ui/preview_shortcuts.dart` — a `PreviewShortcuts` widget that wraps its
+child in a `Shortcuts` + `Actions` pair. Defines three `Intent` subclasses
+(`ToggleToolbarIntent`, `ToggleOrientationIntent`, `ReassembleIntent`) bound to
+`SingleActivator` with `meta` on macOS and `control` elsewhere (detected via
+`defaultTargetPlatform`). Wired into `PreviewOverlay` wrapping the `ColoredBox`/`Stack`
+content so it covers all keyboard focus within the overlay.
 
 ### Step 3.2 — macOS menu bar integration
 

--- a/lib/src/ui/preview_overlay.dart
+++ b/lib/src/ui/preview_overlay.dart
@@ -6,6 +6,7 @@ import 'package:flutter/widgets.dart';
 import '../frame/device_frame_widget.dart';
 import '../preview_controller.dart';
 import 'device_picker.dart';
+import 'preview_shortcuts.dart';
 import 'preview_toolbar.dart';
 
 /// Background colour shown behind the device frame.
@@ -56,48 +57,51 @@ class PreviewOverlay extends StatelessWidget {
               textDirection: TextDirection.ltr,
               child: Theme(
                 data: ThemeData(brightness: Brightness.dark),
-                child: ColoredBox(
-                  color: _kBackgroundColor,
-                  child: Stack(
-                    children: [
-                      // Device frame, centered and scaled to fit.
-                      // ClipRect prevents overflow debug banners when the
-                      // emulated device is larger than the available window.
-                      ClipRect(
-                        child: Center(
-                          child: SizedBox(
-                            width: emulated.width,
-                            height: emulated.height,
-                            child: Transform.scale(
-                              scale: scale,
-                              child: DeviceFrameWidget(
-                                profile: controller.activeProfile,
-                                orientation: controller.orientation,
-                                child: child,
+                child: PreviewShortcuts(
+                  controller: controller,
+                  child: ColoredBox(
+                    color: _kBackgroundColor,
+                    child: Stack(
+                      children: [
+                        // Device frame, centered and scaled to fit.
+                        // ClipRect prevents overflow debug banners when the
+                        // emulated device is larger than the available window.
+                        ClipRect(
+                          child: Center(
+                            child: SizedBox(
+                              width: emulated.width,
+                              height: emulated.height,
+                              child: Transform.scale(
+                                scale: scale,
+                                child: DeviceFrameWidget(
+                                  profile: controller.activeProfile,
+                                  orientation: controller.orientation,
+                                  child: child,
+                                ),
                               ),
                             ),
                           ),
                         ),
-                      ),
 
-                      // Floating toolbar — top-center with a small top margin.
-                      if (controller.toolbarVisible)
-                        Positioned(
-                          top: 8.0,
-                          left: 0,
-                          right: 0,
-                          child: Align(
-                            alignment: Alignment.topCenter,
-                            child: PreviewToolbar(controller: controller),
+                        // Floating toolbar — top-center with a small top margin.
+                        if (controller.toolbarVisible)
+                          Positioned(
+                            top: 8.0,
+                            left: 0,
+                            right: 0,
+                            child: Align(
+                              alignment: Alignment.topCenter,
+                              child: PreviewToolbar(controller: controller),
+                            ),
                           ),
-                        ),
 
-                      // Device picker — covers the full overlay when open.
-                      if (controller.devicePickerVisible)
-                        Positioned.fill(
-                          child: DevicePicker(controller: controller),
-                        ),
-                    ],
+                        // Device picker — covers the full overlay when open.
+                        if (controller.devicePickerVisible)
+                          Positioned.fill(
+                            child: DevicePicker(controller: controller),
+                          ),
+                      ],
+                    ),
                   ),
                 ),
               ),

--- a/lib/src/ui/preview_shortcuts.dart
+++ b/lib/src/ui/preview_shortcuts.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/foundation.dart'
+    show defaultTargetPlatform, TargetPlatform;
+import 'package:flutter/services.dart' show LogicalKeyboardKey;
+import 'package:flutter/widgets.dart';
+
+import '../preview_controller.dart';
+
+// ── Intents ───────────────────────────────────────────────────────────────────
+
+/// Fired by `Ctrl+\` / `Cmd+\` — toggles toolbar visibility.
+class ToggleToolbarIntent extends Intent {
+  const ToggleToolbarIntent();
+}
+
+/// Fired by `Ctrl+L` / `Cmd+L` — toggles portrait ↔ landscape.
+class ToggleOrientationIntent extends Intent {
+  const ToggleOrientationIntent();
+}
+
+/// Fired by `Ctrl+R` / `Cmd+R` — reassembles the application.
+class ReassembleIntent extends Intent {
+  const ReassembleIntent();
+}
+
+// ── Widget ────────────────────────────────────────────────────────────────────
+
+/// Wraps [child] in a [Shortcuts] + [Actions] pair that handles the three
+/// preview keyboard shortcuts.
+///
+/// Uses `meta` (⌘) on macOS and `control` on all other platforms.
+class PreviewShortcuts extends StatelessWidget {
+  const PreviewShortcuts({
+    super.key,
+    required this.controller,
+    required this.child,
+  });
+
+  final PreviewController controller;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final useMeta = defaultTargetPlatform == TargetPlatform.macOS;
+
+    return Shortcuts(
+      shortcuts: {
+        SingleActivator(
+          LogicalKeyboardKey.backslash,
+          meta: useMeta,
+          control: !useMeta,
+        ): const ToggleToolbarIntent(),
+        SingleActivator(
+          LogicalKeyboardKey.keyL,
+          meta: useMeta,
+          control: !useMeta,
+        ): const ToggleOrientationIntent(),
+        SingleActivator(
+          LogicalKeyboardKey.keyR,
+          meta: useMeta,
+          control: !useMeta,
+        ): const ReassembleIntent(),
+      },
+      child: Actions(
+        actions: {
+          ToggleToolbarIntent: CallbackAction<ToggleToolbarIntent>(
+            onInvoke: (_) => controller.toggleToolbar(),
+          ),
+          ToggleOrientationIntent: CallbackAction<ToggleOrientationIntent>(
+            onInvoke: (_) => controller.toggleOrientation(),
+          ),
+          ReassembleIntent: CallbackAction<ReassembleIntent>(
+            onInvoke: (_) => WidgetsBinding.instance.reassembleApplication(),
+          ),
+        },
+        child: child,
+      ),
+    );
+  }
+}

--- a/test/ui/preview_shortcuts_test.dart
+++ b/test/ui/preview_shortcuts_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/services.dart' show LogicalKeyboardKey;
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:bezel/src/preview_controller.dart';
+import 'package:bezel/src/ui/preview_shortcuts.dart';
+
+/// Pumps a [PreviewShortcuts] with a focusable child so key events are routed.
+Future<void> _pump(WidgetTester tester, PreviewController controller) async {
+  await tester.pumpWidget(
+    WidgetsApp(
+      color: const Color(0xFF000000),
+      builder: (context, _) => PreviewShortcuts(
+        controller: controller,
+        child: const Focus(autofocus: true, child: SizedBox.expand()),
+      ),
+    ),
+  );
+  // Let autofocus settle.
+  await tester.pump();
+}
+
+void main() {
+  late PreviewController controller;
+
+  setUp(() => controller = PreviewController());
+  tearDown(() => controller.dispose());
+
+  group('PreviewShortcuts', () {
+    testWidgets('Ctrl+\\ toggles toolbar', (tester) async {
+      await _pump(tester, controller);
+      expect(controller.toolbarVisible, isTrue);
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.control);
+      await tester.sendKeyEvent(LogicalKeyboardKey.backslash);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.control);
+
+      expect(controller.toolbarVisible, isFalse);
+    });
+
+    testWidgets('Ctrl+L toggles orientation', (tester) async {
+      await _pump(tester, controller);
+      expect(controller.orientation, isNot(isNull));
+      final before = controller.orientation;
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.control);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyL);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.control);
+
+      expect(controller.orientation, isNot(equals(before)));
+    });
+  });
+}


### PR DESCRIPTION
Implements step 3.1 — keyboard shortcuts for the three main preview actions.

| Shortcut | Action |
|---|---|
| `Ctrl+\` / `Cmd+\` | Toggle toolbar |
| `Ctrl+L` / `Cmd+L` | Toggle orientation |
| `Ctrl+R` / `Cmd+R` | Reassemble application |

- `PreviewShortcuts` widget wraps `Shortcuts` + `Actions`; three named `Intent` subclasses keep the map readable
- Uses `meta` on macOS, `control` elsewhere via `defaultTargetPlatform`
- Installed in `PreviewOverlay` wrapping the `ColoredBox`/`Stack` so it captures focus from any widget in the overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)