### PR TITLE
Add smooth device transition animation (step 3.3)

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -131,15 +131,19 @@ The "Preview" menu contains:
 `MacosPreviewMenu` is integrated into `PreviewOverlay` wrapping the entire
 `ListenableBuilder` so the native menu bar is always present when the overlay is active.
 
-### Step 3.3 — Smooth device transition animation
+### Step 3.3 — Smooth device transition animation [done]
 
-Update `PreviewOverlay` to animate between device profiles:
+Updated `PreviewOverlay` to animate between device profiles:
 
-- Wrap `DeviceFrameWidget` in an `AnimatedContainer` for size changes
-- Use `AnimatedSwitcher` with a fade + scale transition when the profile changes
-- Duration: 250ms, curve: `Curves.easeInOut`
-
-This is purely cosmetic — no logic changes.
+- Replaced `SizedBox` + `Transform.scale` with `AnimatedContainer` whose `width` and
+  `height` are `emulatedSize × scale`, so the outer bounding box interpolates smoothly
+  when the device or orientation changes. This also eliminates the separate
+  `Transform.scale` wrapper.
+- Wrapped `DeviceFrameWidget` in an `AnimatedSwitcher` (250 ms, `Curves.easeInOut`) with a
+  custom `transitionBuilder` that combines `FadeTransition` + `ScaleTransition`
+  (0.92 → 1.0) for a subtle grow-in / shrink-out cross-fade.
+- `DeviceFrameWidget` is keyed on `'${profile.id}_${orientation.name}'` so both profile
+  and orientation changes trigger the switcher.
 
 ### Step 3.4 — VM service hot-reload integration (optional / experimental)
 

--- a/lib/src/ui/preview_overlay.dart
+++ b/lib/src/ui/preview_overlay.dart
@@ -16,6 +16,11 @@ import 'preview_toolbar.dart';
 /// to read clearly without the background feeling overly bright.
 const _kBackgroundColor = Color(0xFF4A4A52);
 
+/// Duration used for both the [AnimatedContainer] size transition and the
+/// [AnimatedSwitcher] fade+scale transition when the device profile or
+/// orientation changes.
+const _kTransitionDuration = Duration(milliseconds: 250);
+
 /// Wraps the app in a device-frame preview UI.
 ///
 /// Uses [LayoutBuilder] + [ListenableBuilder] to react to both window-size
@@ -67,16 +72,41 @@ class PreviewOverlay extends StatelessWidget {
                       child: Stack(
                         children: [
                           // Device frame, centered and scaled to fit.
-                          // ClipRect prevents overflow debug banners when the
-                          // emulated device is larger than the available window.
+                          // AnimatedContainer smoothly interpolates the outer
+                          // dimensions when the device or orientation changes.
+                          // AnimatedSwitcher cross-fades + scales the frame
+                          // widget itself. ClipRect prevents overflow debug
+                          // banners when the emulated device is larger than
+                          // the available window.
                           ClipRect(
                             child: Center(
-                              child: SizedBox(
-                                width: emulated.width,
-                                height: emulated.height,
-                                child: Transform.scale(
-                                  scale: scale,
+                              child: AnimatedContainer(
+                                duration: _kTransitionDuration,
+                                curve: Curves.easeInOut,
+                                width: emulated.width * scale,
+                                height: emulated.height * scale,
+                                child: AnimatedSwitcher(
+                                  duration: _kTransitionDuration,
+                                  switchInCurve: Curves.easeInOut,
+                                  switchOutCurve: Curves.easeInOut,
+                                  transitionBuilder: (child, animation) =>
+                                      FadeTransition(
+                                        opacity: animation,
+                                        child: ScaleTransition(
+                                          scale: animation.drive(
+                                            Tween<double>(
+                                              begin: 0.92,
+                                              end: 1.0,
+                                            ),
+                                          ),
+                                          child: child,
+                                        ),
+                                      ),
                                   child: DeviceFrameWidget(
+                                    key: ValueKey(
+                                      '${controller.activeProfile.id}_'
+                                      '${controller.orientation.name}',
+                                    ),
                                     profile: controller.activeProfile,
                                     orientation: controller.orientation,
                                     child: child,

--- a/test/ui/preview_overlay_test.dart
+++ b/test/ui/preview_overlay_test.dart
@@ -63,7 +63,7 @@ void main() {
 
       final next = DeviceDatabase.all.firstWhere((p) => p.id != before.id);
       controller.setProfile(next);
-      await tester.pump();
+      await tester.pumpAndSettle();
 
       final after = tester
           .widget<DeviceFrameWidget>(find.byType(DeviceFrameWidget))
@@ -90,7 +90,7 @@ void main() {
       expect(before, DeviceOrientation.portrait);
 
       controller.toggleOrientation();
-      await tester.pump();
+      await tester.pumpAndSettle();
 
       final after = tester
           .widget<DeviceFrameWidget>(find.byType(DeviceFrameWidget))
@@ -199,6 +199,91 @@ void main() {
       );
 
       expect(find.byType(DevicePicker), findsOneWidget);
+    });
+  });
+
+  group('PreviewOverlay animations', () {
+    late PreviewController controller;
+
+    setUp(() => controller = PreviewController());
+    tearDown(() => controller.dispose());
+
+    Widget wrap(PreviewController c) => Directionality(
+      textDirection: TextDirection.ltr,
+      child: PreviewOverlay(controller: c, child: const SizedBox.expand()),
+    );
+
+    testWidgets('AnimatedContainer and AnimatedSwitcher are present', (
+      tester,
+    ) async {
+      await tester.pumpWidget(wrap(controller));
+      expect(find.byType(AnimatedContainer), findsOneWidget);
+      expect(find.byType(AnimatedSwitcher), findsOneWidget);
+    });
+
+    testWidgets('AnimatedContainer uses 250 ms duration', (tester) async {
+      await tester.pumpWidget(wrap(controller));
+      final container = tester.widget<AnimatedContainer>(
+        find.byType(AnimatedContainer),
+      );
+      expect(container.duration, const Duration(milliseconds: 250));
+    });
+
+    testWidgets('DeviceFrameWidget key encodes profile id and orientation', (
+      tester,
+    ) async {
+      await tester.pumpWidget(wrap(controller));
+      final frame = tester.widget<DeviceFrameWidget>(
+        find.byType(DeviceFrameWidget),
+      );
+      final key = frame.key as ValueKey<String>;
+      expect(key.value, contains(controller.activeProfile.id));
+      expect(key.value, contains(controller.orientation.name));
+    });
+
+    testWidgets('profile change gives DeviceFrameWidget a new key', (
+      tester,
+    ) async {
+      await tester.pumpWidget(wrap(controller));
+      final keyBefore =
+          (tester.widget<DeviceFrameWidget>(find.byType(DeviceFrameWidget)).key
+                  as ValueKey<String>)
+              .value;
+
+      final next = DeviceDatabase.all.firstWhere(
+        (p) => p != controller.activeProfile,
+      );
+      controller.setProfile(next);
+      await tester.pump(); // one frame: both old + new widget exist
+
+      final frames = tester.widgetList<DeviceFrameWidget>(
+        find.byType(DeviceFrameWidget),
+      );
+      expect(
+        frames.any((w) => (w.key as ValueKey<String>).value != keyBefore),
+        isTrue,
+      );
+    });
+
+    testWidgets('orientation toggle gives DeviceFrameWidget a new key', (
+      tester,
+    ) async {
+      await tester.pumpWidget(wrap(controller));
+      final keyBefore =
+          (tester.widget<DeviceFrameWidget>(find.byType(DeviceFrameWidget)).key
+                  as ValueKey<String>)
+              .value;
+
+      controller.toggleOrientation();
+      await tester.pump();
+
+      final frames = tester.widgetList<DeviceFrameWidget>(
+        find.byType(DeviceFrameWidget),
+      );
+      expect(
+        frames.any((w) => (w.key as ValueKey<String>).value != keyBefore),
+        isTrue,
+      );
     });
   });
 


### PR DESCRIPTION
Animates the device frame when switching profiles or orientation.

- `AnimatedContainer` smoothly interpolates the frame bounding box size (250 ms, easeInOut); also eliminates the separate `Transform.scale` wrapper by folding scale into the container dimensions directly
- `AnimatedSwitcher` wraps `DeviceFrameWidget` with a `FadeTransition` + `ScaleTransition` (0.92→1.0) cross-fade between frames
- `DeviceFrameWidget` keyed on `'${profile.id}_${orientation.name}'` so both profile and orientation changes trigger the switcher
- Existing overlay tests updated to `pumpAndSettle` through transitions; 5 new animation-specific tests added

🤖 Generated with [Claude Code](https://claude.com/claude-code)