### PR TITLE
Add screenCornerRadius to DeviceProfile, remove DeviceFrameStyle (step 4.1)

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -151,21 +151,12 @@ shortcuts table, supported devices table, and known limitations section sourced 
 Feedback-driven improvements to the controls, rendering fidelity, and window sizing after
 initial MVP usage.
 
-### Step 4.1 — Add `screenCornerRadius` to DeviceProfile, remove `DeviceFrameStyle`
+### Step 4.1 — Add `screenCornerRadius` to DeviceProfile, remove `DeviceFrameStyle` [done]
 
-Add a `screenCornerRadius` field (double, logical pixels) to `DeviceProfile`. Remove the
-`DeviceFrameStyle` enum and `frameStyle` field — cutout type is already captured by the
-`ScreenCutout` sealed hierarchy, making `frameStyle` redundant once bezels are removed.
-
-Update all profiles in `DeviceDatabase` with per-device corner radius values (approximate):
-- Modern iPhones (15 series): ~47pt
-- iPhone SE: 0
-- iPads: 0
-- Pixels: ~20–28dp (varies by model)
-- Samsung Galaxy S24: ~26dp
-
-Annotate uncertain values with source comments. Update all code that references
-`DeviceFrameStyle` or `frameStyle` (painter, widget, tests).
+Added `screenCornerRadius` (double, logical pixels) to `DeviceProfile` and removed
+`DeviceFrameStyle` enum and `frameStyle` field; updated all 10 device profiles with
+per-device corner radius values (annotated with data sources), and updated the painter to
+infer classic vs modern layout from the `ScreenCutout` type.
 
 ### Step 4.2 — Remove device frame body/bezels, clip at corners and cutouts
 

--- a/lib/src/devices/device_database.dart
+++ b/lib/src/devices/device_database.dart
@@ -19,7 +19,7 @@ const List<DeviceProfile> kDeviceProfiles = [
     devicePixelRatio: 2.0,
     safeAreaPortrait: EdgeInsets.only(top: 20),
     safeAreaLandscape: EdgeInsets.zero,
-    frameStyle: DeviceFrameStyle.classic,
+    screenCornerRadius: 0, // flat-cornered display behind large bezels
     cutout: NoCutout(),
   ),
 
@@ -31,7 +31,7 @@ const List<DeviceProfile> kDeviceProfiles = [
     devicePixelRatio: 3.0,
     safeAreaPortrait: EdgeInsets.only(top: 59, bottom: 34),
     safeAreaLandscape: EdgeInsets.only(left: 59, right: 59, bottom: 21),
-    frameStyle: DeviceFrameStyle.dynamicIsland,
+    screenCornerRadius: 47, // community measurement; to be refined in step 4.6
     cutout: DynamicIslandCutout(size: Size(37, 12), topOffset: 14),
   ),
 
@@ -43,7 +43,7 @@ const List<DeviceProfile> kDeviceProfiles = [
     devicePixelRatio: 3.0,
     safeAreaPortrait: EdgeInsets.only(top: 59, bottom: 34),
     safeAreaLandscape: EdgeInsets.only(left: 59, right: 59, bottom: 21),
-    frameStyle: DeviceFrameStyle.dynamicIsland,
+    screenCornerRadius: 47, // community measurement; to be refined in step 4.6
     cutout: DynamicIslandCutout(size: Size(37, 12), topOffset: 14),
   ),
 
@@ -55,7 +55,7 @@ const List<DeviceProfile> kDeviceProfiles = [
     devicePixelRatio: 3.0,
     safeAreaPortrait: EdgeInsets.only(top: 59, bottom: 34),
     safeAreaLandscape: EdgeInsets.only(left: 59, right: 59, bottom: 21),
-    frameStyle: DeviceFrameStyle.dynamicIsland,
+    screenCornerRadius: 47, // community measurement; to be refined in step 4.6
     cutout: DynamicIslandCutout(size: Size(37, 12), topOffset: 14),
   ),
 
@@ -67,7 +67,7 @@ const List<DeviceProfile> kDeviceProfiles = [
     devicePixelRatio: 2.0,
     safeAreaPortrait: EdgeInsets.only(top: 24, bottom: 20),
     safeAreaLandscape: EdgeInsets.only(top: 20, bottom: 20),
-    frameStyle: DeviceFrameStyle.classic,
+    screenCornerRadius: 0, // flat-cornered display behind large bezels
     cutout: NoCutout(),
   ),
 
@@ -79,7 +79,7 @@ const List<DeviceProfile> kDeviceProfiles = [
     devicePixelRatio: 2.0,
     safeAreaPortrait: EdgeInsets.only(top: 24, bottom: 20),
     safeAreaLandscape: EdgeInsets.only(top: 20, bottom: 20),
-    frameStyle: DeviceFrameStyle.classic,
+    screenCornerRadius: 0, // flat-cornered display behind large bezels
     cutout: NoCutout(),
   ),
 
@@ -92,7 +92,8 @@ const List<DeviceProfile> kDeviceProfiles = [
     devicePixelRatio: 2.625,
     safeAreaPortrait: EdgeInsets.only(top: 24, bottom: 24),
     safeAreaLandscape: EdgeInsets.only(bottom: 24),
-    frameStyle: DeviceFrameStyle.punchHole,
+    screenCornerRadius:
+        26, // community approximation; Samsung config is proprietary
     cutout: PunchHoleCutout(diameter: 10, topOffset: 12),
   ),
 
@@ -104,7 +105,7 @@ const List<DeviceProfile> kDeviceProfiles = [
     devicePixelRatio: 2.625,
     safeAreaPortrait: EdgeInsets.only(top: 24, bottom: 24),
     safeAreaLandscape: EdgeInsets.only(bottom: 24),
-    frameStyle: DeviceFrameStyle.punchHole,
+    screenCornerRadius: 22, // approximate; to be refined from AOSP in step 4.6
     cutout: PunchHoleCutout(diameter: 11, topOffset: 13),
   ),
 
@@ -116,7 +117,7 @@ const List<DeviceProfile> kDeviceProfiles = [
     devicePixelRatio: 2.625,
     safeAreaPortrait: EdgeInsets.only(top: 24, bottom: 24),
     safeAreaLandscape: EdgeInsets.only(bottom: 24),
-    frameStyle: DeviceFrameStyle.punchHole,
+    screenCornerRadius: 25, // approximate; to be refined from AOSP in step 4.6
     cutout: PunchHoleCutout(diameter: 11, topOffset: 13),
   ),
 
@@ -128,7 +129,7 @@ const List<DeviceProfile> kDeviceProfiles = [
     devicePixelRatio: 3.0,
     safeAreaPortrait: EdgeInsets.only(top: 24, bottom: 24),
     safeAreaLandscape: EdgeInsets.only(bottom: 24),
-    frameStyle: DeviceFrameStyle.punchHole,
+    screenCornerRadius: 25, // approximate; to be refined from AOSP in step 4.6
     cutout: PunchHoleCutout(diameter: 11, topOffset: 13),
   ),
 ];

--- a/lib/src/devices/device_profile.dart
+++ b/lib/src/devices/device_profile.dart
@@ -11,21 +11,6 @@ enum DevicePlatform {
   android,
 }
 
-/// The visual style of the device frame, driven by the camera cutout design.
-enum DeviceFrameStyle {
-  /// Wide notch at the top — older iPhones (X–14).
-  notch,
-
-  /// Dynamic Island pill — iPhone 15 and later.
-  dynamicIsland,
-
-  /// Small circular punch-hole — Pixel, Galaxy S series.
-  punchHole,
-
-  /// Full bezels with no cutout — iPhone SE, iPads.
-  classic,
-}
-
 /// Screen orientation.
 enum DeviceOrientation {
   /// Taller than wide.
@@ -62,8 +47,12 @@ class DeviceProfile {
   /// Safe area insets in landscape orientation.
   final EdgeInsets safeAreaLandscape;
 
-  /// Visual frame style used by [DeviceFramePainter].
-  final DeviceFrameStyle frameStyle;
+  /// Screen corner radius in logical pixels.
+  ///
+  /// Used to clip the device screen to its true rounded-corner shape so the
+  /// preview background shows through where a real display's glass would end.
+  /// A value of 0 means square corners (e.g. iPhone SE, iPads).
+  final double screenCornerRadius;
 
   /// Camera cutout geometry in portrait orientation.
   final ScreenCutout cutout;
@@ -76,7 +65,7 @@ class DeviceProfile {
     required this.devicePixelRatio,
     required this.safeAreaPortrait,
     required this.safeAreaLandscape,
-    required this.frameStyle,
+    required this.screenCornerRadius,
     required this.cutout,
   });
 

--- a/lib/src/frame/device_frame_painter.dart
+++ b/lib/src/frame/device_frame_painter.dart
@@ -50,7 +50,7 @@ class DeviceFramePainter extends CustomPainter {
     DeviceOrientation orientation,
   ) {
     return _bezelsFor(
-      profile.frameStyle,
+      profile,
       orientation,
     ).deflateRect(Offset.zero & painterSize);
   }
@@ -82,15 +82,10 @@ class DeviceFramePainter extends CustomPainter {
   // ---------------------------------------------------------------------------
 
   void _drawDecorations(Canvas canvas, Size size, Rect screenRect) {
-    switch (profile.frameStyle) {
-      case DeviceFrameStyle.classic:
-        _drawClassicDecorations(canvas, size, screenRect);
-      case DeviceFrameStyle.notch:
-      case DeviceFrameStyle.dynamicIsland:
-      case DeviceFrameStyle.punchHole:
-        // No additional bezel decorations for modern frames — the cutout
-        // clip below handles the camera housing appearance.
-        break;
+    // Classic layout: devices with no cutout (iPhone SE, iPads) have thick
+    // bezels and decorative speaker / home-button indicators.
+    if (profile.cutout is NoCutout) {
+      _drawClassicDecorations(canvas, size, screenRect);
     }
   }
 
@@ -234,26 +229,26 @@ class DeviceFramePainter extends CustomPainter {
   // ---------------------------------------------------------------------------
 
   static EdgeInsets _bezelsFor(
-    DeviceFrameStyle style,
+    DeviceProfile profile,
     DeviceOrientation orientation,
   ) {
-    return switch (style) {
-      DeviceFrameStyle.classic =>
-        orientation == DeviceOrientation.portrait
-            ? const EdgeInsets.only(
-                top: _kClassicTopBezel,
-                bottom: _kClassicBottomBezel,
-                left: _kSideBezel,
-                right: _kSideBezel,
-              )
-            : const EdgeInsets.only(
-                top: _kSideBezel,
-                bottom: _kSideBezel,
-                left: _kClassicTopBezel,
-                right: _kClassicBottomBezel,
-              ),
-      _ => const EdgeInsets.all(_kModernBezel),
-    };
+    // Classic layout: devices with no cutout use asymmetric thick bezels.
+    if (profile.cutout is NoCutout) {
+      return orientation == DeviceOrientation.portrait
+          ? const EdgeInsets.only(
+              top: _kClassicTopBezel,
+              bottom: _kClassicBottomBezel,
+              left: _kSideBezel,
+              right: _kSideBezel,
+            )
+          : const EdgeInsets.only(
+              top: _kSideBezel,
+              bottom: _kSideBezel,
+              left: _kClassicTopBezel,
+              right: _kClassicBottomBezel,
+            );
+    }
+    return const EdgeInsets.all(_kModernBezel);
   }
 
   @override

--- a/test/devices/device_profile_test.dart
+++ b/test/devices/device_profile_test.dart
@@ -8,10 +8,7 @@ void main() {
   // A reusable portrait size for rotation math checks.
   const portraitSize = Size(390, 844);
 
-  DeviceProfile makeProfile({
-    required ScreenCutout cutout,
-    DeviceFrameStyle frameStyle = DeviceFrameStyle.classic,
-  }) {
+  DeviceProfile makeProfile({required ScreenCutout cutout}) {
     return DeviceProfile(
       id: 'test',
       name: 'Test Device',
@@ -20,7 +17,7 @@ void main() {
       devicePixelRatio: 3.0,
       safeAreaPortrait: const EdgeInsets.only(top: 59, bottom: 34),
       safeAreaLandscape: const EdgeInsets.only(left: 59, right: 59, bottom: 21),
-      frameStyle: frameStyle,
+      screenCornerRadius: 0,
       cutout: cutout,
     );
   }
@@ -143,7 +140,6 @@ void main() {
     test('portrait returns the original DynamicIslandCutout', () {
       final profile = makeProfile(
         cutout: const DynamicIslandCutout(size: Size(37, 12), topOffset: 14),
-        frameStyle: DeviceFrameStyle.dynamicIsland,
       );
       expect(
         profile.cutoutForOrientation(DeviceOrientation.portrait),
@@ -154,7 +150,6 @@ void main() {
     test('landscape produces a different (rotated) cutout type', () {
       final profile = makeProfile(
         cutout: const DynamicIslandCutout(size: Size(37, 12), topOffset: 14),
-        frameStyle: DeviceFrameStyle.dynamicIsland,
       );
       final landscape = profile.cutoutForOrientation(
         DeviceOrientation.landscape,

--- a/test/frame/device_frame_painter_test.dart
+++ b/test/frame/device_frame_painter_test.dart
@@ -7,9 +7,8 @@ import 'package:bezel/src/devices/screen_cutout.dart';
 import 'package:bezel/src/frame/device_frame_painter.dart';
 
 void main() {
-  // A helper that builds a DeviceProfile for a given frame style and cutout.
+  // A helper that builds a DeviceProfile for a given cutout.
   DeviceProfile makeProfile({
-    required DeviceFrameStyle frameStyle,
     ScreenCutout cutout = const NoCutout(),
     Size logicalSize = const Size(390, 844),
   }) {
@@ -21,7 +20,7 @@ void main() {
       devicePixelRatio: 3.0,
       safeAreaPortrait: const EdgeInsets.only(top: 59, bottom: 34),
       safeAreaLandscape: const EdgeInsets.only(left: 59, right: 59, bottom: 21),
-      frameStyle: frameStyle,
+      screenCornerRadius: 0,
       cutout: cutout,
     );
   }
@@ -29,8 +28,7 @@ void main() {
   group('DeviceFramePainter.screenRectForSize', () {
     test('screen rect is contained within painter bounds', () {
       const painterSize = Size(390, 844);
-      for (final style in DeviceFrameStyle.values) {
-        final profile = makeProfile(frameStyle: style);
+      for (final profile in DeviceDatabase.all) {
         final rect = DeviceFramePainter.screenRectForSize(
           painterSize,
           profile,
@@ -43,9 +41,9 @@ void main() {
       }
     });
 
-    test('classic portrait has larger top and bottom bezels than sides', () {
+    test('NoCutout portrait has larger top and bottom bezels than sides', () {
       const painterSize = Size(390, 844);
-      final profile = makeProfile(frameStyle: DeviceFrameStyle.classic);
+      final profile = makeProfile(cutout: const NoCutout());
       final rect = DeviceFramePainter.screenRectForSize(
         painterSize,
         profile,
@@ -60,10 +58,10 @@ void main() {
     });
 
     test(
-      'classic landscape has larger left and right bezels than top/bottom',
+      'NoCutout landscape has larger left and right bezels than top/bottom',
       () {
         const painterSize = Size(844, 390);
-        final profile = makeProfile(frameStyle: DeviceFrameStyle.classic);
+        final profile = makeProfile(cutout: const NoCutout());
         final rect = DeviceFramePainter.screenRectForSize(
           painterSize,
           profile,
@@ -78,34 +76,35 @@ void main() {
       },
     );
 
-    test('modern styles have uniform small bezels in portrait', () {
+    test('modern cutout profiles have uniform small bezels in portrait', () {
       const painterSize = Size(390, 844);
-      for (final style in [
-        DeviceFrameStyle.dynamicIsland,
-        DeviceFrameStyle.punchHole,
-        DeviceFrameStyle.notch,
-      ]) {
-        final profile = makeProfile(frameStyle: style);
+      final modernCutouts = <ScreenCutout>[
+        const DynamicIslandCutout(size: Size(37, 12), topOffset: 14),
+        const PunchHoleCutout(diameter: 11, topOffset: 13),
+        const NotchCutout(size: Size(150, 30)),
+      ];
+      for (final cutout in modernCutouts) {
+        final profile = makeProfile(cutout: cutout);
         final rect = DeviceFramePainter.screenRectForSize(
           painterSize,
           profile,
           DeviceOrientation.portrait,
         );
-        // All four bezels should be equal for modern styles.
+        // All four bezels should be equal for modern cutout profiles.
         expect(
           rect.left,
           equals(painterSize.width - rect.right),
-          reason: 'style=$style left/right bezels differ',
+          reason: '${cutout.runtimeType} left/right bezels differ',
         );
         expect(
           rect.top,
           equals(painterSize.height - rect.bottom),
-          reason: 'style=$style top/bottom bezels differ',
+          reason: '${cutout.runtimeType} top/bottom bezels differ',
         );
         expect(
           rect.left,
           equals(rect.top),
-          reason: 'style=$style side/top bezels differ',
+          reason: '${cutout.runtimeType} side/top bezels differ',
         );
       }
     });
@@ -135,11 +134,9 @@ void main() {
   });
 
   group('DeviceFramePainter rendering', () {
-    // Verify that painting all four frame styles does not throw, and that the
-    // CustomPaint widget builds without error.
-    for (final style in DeviceFrameStyle.values) {
-      testWidgets('renders $style without throwing', (tester) async {
-        final profile = makeProfile(frameStyle: style);
+    // Verify that every real database profile renders without throwing.
+    for (final profile in DeviceDatabase.all) {
+      testWidgets('renders ${profile.id} without throwing', (tester) async {
         await tester.pumpWidget(
           MaterialApp(
             home: SizedBox(
@@ -159,10 +156,7 @@ void main() {
     }
 
     testWidgets('NoCutout profile renders without exception', (tester) async {
-      final profile = makeProfile(
-        frameStyle: DeviceFrameStyle.classic,
-        cutout: const NoCutout(),
-      );
+      final profile = makeProfile(cutout: const NoCutout());
       await tester.pumpWidget(
         MaterialApp(
           home: SizedBox(


### PR DESCRIPTION
Implements step 4.1 of the Phase 4 refinement plan.

- Adds `screenCornerRadius` (double, logical pixels) to `DeviceProfile` — used in step 4.2 to clip content at real device screen corners
- Removes `DeviceFrameStyle` enum and `frameStyle` field; cutout type is already fully captured by the `ScreenCutout` sealed hierarchy
- Updates all 10 device profiles with per-device corner radius values (47pt for modern iPhones, 0 for SE/iPads, 22–26dp for Android; each annotated with data source)
- Updates `DeviceFramePainter` to infer classic vs modern bezel layout from `profile.cutout is NoCutout` rather than the removed enum
- Updates painter and profile tests accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)