### PR TITLE
Update window sizing: drop frame padding, add reposition logic (step 4.4)

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -180,7 +180,7 @@ shape and current button set.
 
 Update device picker positioning if needed. Update tests.
 
-### Step 4.4 — Update window sizing
+### Step 4.4 — Update window sizing [done]
 
 In `WindowManagerSizingService`:
 - Remove `_kFramePadding` (no bezels).

--- a/lib/src/window/window_manager_sizing_service.dart
+++ b/lib/src/window/window_manager_sizing_service.dart
@@ -1,17 +1,14 @@
 import 'dart:ui' as ui;
 
-import 'package:flutter/widgets.dart' show WidgetsBinding;
+import 'package:flutter/widgets.dart' show Offset, WidgetsBinding;
 import 'package:window_manager/window_manager.dart';
 
 import '../devices/device_profile.dart';
 import 'window_sizing_service.dart';
 
-/// Extra horizontal padding added around the emulated logical size to
-/// accommodate the device frame chrome on each side.
-const double _kFramePadding = 80.0;
-
-/// Extra vertical padding at the top for the floating toolbar (step 2.5).
-const double _kToolbarHeight = 60.0;
+/// Height reserved at the bottom of the window for the floating toolbar,
+/// including its bottom margin.
+const double _kToolbarAreaHeight = 40.0;
 
 /// Minimum window dimensions — prevents the window from shrinking to a
 /// non-interactive size when a very small device profile is selected.
@@ -45,10 +42,24 @@ class WindowManagerSizingService implements WindowSizingService {
 
     await windowManager.setMinimumSize(_kMinWindowSize);
     await windowManager.setSize(clamped);
+
+    // Reposition the window if it would extend off the right or bottom edge
+    // of the screen after the resize.
+    final pos = await windowManager.getPosition();
+    final maxLeft = screen.width - clamped.width;
+    final maxTop = screen.height - clamped.height;
+    if (pos.dx > maxLeft || pos.dy > maxTop) {
+      await windowManager.setPosition(
+        Offset(pos.dx.clamp(0.0, maxLeft), pos.dy.clamp(0.0, maxTop)),
+      );
+    }
   }
 
   /// Computes the ideal window size for [profile] at [orientation] before
   /// screen-size clamping is applied.
+  ///
+  /// Window width matches the emulated logical width exactly (no bezel padding).
+  /// Window height adds [_kToolbarAreaHeight] for the bottom toolbar.
   ///
   /// Exposed for unit testing without a real window.
   static ui.Size computeTargetSize(
@@ -56,10 +67,7 @@ class WindowManagerSizingService implements WindowSizingService {
     DeviceOrientation orientation,
   ) {
     final emulated = profile.logicalSizeForOrientation(orientation);
-    return ui.Size(
-      emulated.width + _kFramePadding * 2,
-      emulated.height + _kFramePadding + _kToolbarHeight,
-    );
+    return ui.Size(emulated.width, emulated.height + _kToolbarAreaHeight);
   }
 
   /// Returns the logical size of the display the app is currently on.

--- a/test/window/window_sizing_service_test.dart
+++ b/test/window/window_sizing_service_test.dart
@@ -21,38 +21,40 @@ class _SpySizingService implements WindowSizingService {
 
 void main() {
   group('WindowManagerSizingService.computeTargetSize', () {
-    test('adds frame padding and toolbar height to portrait emulated size', () {
-      final profile = DeviceDatabase.defaultProfile; // iPhone 15: 393×852
-      final size = WindowManagerSizingService.computeTargetSize(
-        profile,
-        DeviceOrientation.portrait,
-      );
-      expect(size.width, profile.logicalSize.width + 80 * 2);
-      expect(size.height, profile.logicalSize.height + 80 + 60);
-    });
+    test(
+      'portrait target width equals emulated width, height adds toolbar area',
+      () {
+        final profile = DeviceDatabase.defaultProfile; // iPhone 15: 393×852
+        final size = WindowManagerSizingService.computeTargetSize(
+          profile,
+          DeviceOrientation.portrait,
+        );
+        expect(size.width, profile.logicalSize.width);
+        expect(
+          size.height,
+          profile.logicalSize.height + 40,
+        ); // _kToolbarAreaHeight
+      },
+    );
 
-    test('uses landscape dimensions in landscape orientation', () {
+    test('landscape target uses swapped emulated dimensions', () {
       final profile = DeviceDatabase.defaultProfile;
-      final portrait = WindowManagerSizingService.computeTargetSize(
-        profile,
-        DeviceOrientation.portrait,
-      );
       final landscape = WindowManagerSizingService.computeTargetSize(
         profile,
         DeviceOrientation.landscape,
       );
-      // Width and height are swapped for landscape.
-      expect(landscape.width, portrait.height - 80 - 60 + 80 * 2);
-      expect(landscape.height, portrait.width - 80 * 2 + 80 + 60);
+      // Landscape swaps the emulated width/height.
+      expect(landscape.width, profile.logicalSize.height);
+      expect(landscape.height, profile.logicalSize.width + 40);
     });
 
-    test('target is wider than emulated device', () {
+    test('target height exceeds emulated height by toolbar area', () {
       final profile = DeviceDatabase.defaultProfile;
       final size = WindowManagerSizingService.computeTargetSize(
         profile,
         DeviceOrientation.portrait,
       );
-      expect(size.width, greaterThan(profile.logicalSize.width));
+      expect(size.width, equals(profile.logicalSize.width));
       expect(size.height, greaterThan(profile.logicalSize.height));
     });
   });


### PR DESCRIPTION
Removes the old bezel frame padding from window sizing and adds bounds-aware repositioning.

- `computeTargetSize`: window width = emulated logical width (no `_kFramePadding`); window height = emulated height + `_kToolbarAreaHeight` (40px)
- `applyProfile`: after resizing, checks if the window extends off the right or bottom edge of the screen and repositions to keep it fully visible
- Removes `_kFramePadding = 80`, renames `_kToolbarHeight` → `_kToolbarAreaHeight`