### PR TITLE
Update overlay layout for aspect-ratio scaling (step 4.5)

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -195,7 +195,7 @@ Add bounds logic:
 
 Update `computeTargetSize` and tests.
 
-### Step 4.5 — Update overlay layout for aspect-ratio scaling
+### Step 4.5 — Update overlay layout for aspect-ratio scaling [done]
 
 Update `PreviewOverlay`:
 - Content area = available space minus toolbar height at bottom.

--- a/lib/src/ui/preview_overlay.dart
+++ b/lib/src/ui/preview_overlay.dart
@@ -16,11 +16,19 @@ import 'preview_toolbar.dart';
 /// to read clearly without the background feeling overly bright.
 const _kBackgroundColor = Color(0xFF4A4A52);
 
+/// Height reserved at the bottom of the window for the floating toolbar.
+///
+/// Must stay in sync with `_kToolbarAreaHeight` in
+/// `window_manager_sizing_service.dart`.
+const double _kToolbarAreaHeight = 40.0;
+
 /// Wraps the app in a device-frame preview UI.
 ///
 /// Uses [LayoutBuilder] + [ListenableBuilder] to react to both window-size
-/// changes and [PreviewController] state changes. Centers a [ScreenClipWidget]
-/// scaled to fit the available space, with a dark matte background.
+/// changes and [PreviewController] state changes. Scales the [ScreenClipWidget]
+/// to fill the content area (available space minus the toolbar strip at the
+/// bottom), letterboxing with the background colour on whichever axis has
+/// leftover space.
 ///
 /// Installed automatically by [PreviewBinding.wrapWithDefaultView]. Should not
 /// need to be used directly.
@@ -44,15 +52,24 @@ class PreviewOverlay extends StatelessWidget {
       child: ListenableBuilder(
         listenable: controller,
         builder: (context, _) {
+          if (controller.passthroughMode) {
+            return child;
+          }
+
           return LayoutBuilder(
             builder: (context, constraints) {
               final available = constraints.biggest;
               final emulated = controller.emulatedLogicalSize;
-              final scale = _computeScale(available, emulated);
-
-              if (controller.passthroughMode) {
-                return child;
-              }
+              // Reserve the bottom strip for the toolbar; scale content to fill
+              // the remaining area.
+              final contentArea = Size(
+                available.width,
+                (available.height - _kToolbarAreaHeight).clamp(
+                  1.0,
+                  double.infinity,
+                ),
+              );
+              final scale = computeScale(contentArea, emulated);
 
               // Directionality + Theme are provided here because the overlay
               // sits above the user's MaterialApp and has no such ancestors.
@@ -66,21 +83,21 @@ class PreviewOverlay extends StatelessWidget {
                       color: _kBackgroundColor,
                       child: Stack(
                         children: [
-                          // Device frame, centered and scaled to fit.
-                          // ClipRect prevents overflow debug banners when the
-                          // emulated device is larger than the available window.
-                          ClipRect(
+                          // Content area: fills window above the toolbar strip.
+                          // Device frame is centered and letterboxed within it.
+                          Positioned(
+                            top: 0,
+                            left: 0,
+                            right: 0,
+                            bottom: _kToolbarAreaHeight,
                             child: Center(
                               child: SizedBox(
-                                width: emulated.width,
-                                height: emulated.height,
-                                child: Transform.scale(
-                                  scale: scale,
-                                  child: ScreenClipWidget(
-                                    profile: controller.activeProfile,
-                                    orientation: controller.orientation,
-                                    child: child,
-                                  ),
+                                width: emulated.width * scale,
+                                height: emulated.height * scale,
+                                child: ScreenClipWidget(
+                                  profile: controller.activeProfile,
+                                  orientation: controller.orientation,
+                                  child: child,
                                 ),
                               ),
                             ),
@@ -116,23 +133,16 @@ class PreviewOverlay extends StatelessWidget {
     );
   }
 
-  /// Computes the uniform scale factor to apply to the device frame.
+  /// Computes the uniform scale factor to fit [emulated] inside [contentArea].
   ///
-  /// Returns 1.0 when the emulated size fits within 90 % of [available].
-  /// Otherwise returns the largest scale that fits within [available] with a
-  /// 10 % margin.
-  static double computeScale(Size available, Size emulated) =>
-      _computeScale(available, emulated);
-
-  static double _computeScale(Size available, Size emulated) {
-    if (emulated.width <= available.width * 0.9 &&
-        emulated.height <= available.height * 0.9) {
-      return 1.0;
-    }
-    return math.min(
-          available.width / emulated.width,
-          available.height / emulated.height,
-        ) *
-        0.9;
+  /// Returns the largest scale ≤ 1.0 such that the scaled emulated size fits
+  /// within [contentArea]. Returns 1.0 when the emulated size already fits.
+  static double computeScale(Size contentArea, Size emulated) {
+    return math
+        .min(
+          contentArea.width / emulated.width,
+          contentArea.height / emulated.height,
+        )
+        .clamp(0.0, 1.0);
   }
 }

--- a/test/ui/preview_overlay_test.dart
+++ b/test/ui/preview_overlay_test.dart
@@ -203,32 +203,40 @@ void main() {
   });
 
   group('PreviewOverlay.computeScale', () {
-    test('returns 1.0 when device fits within 90% of available space', () {
-      // 390 <= 500 * 0.9 = 450, 844 <= 1000 * 0.9 = 900 → scale = 1.0
+    test('returns 1.0 when content area is larger than emulated size', () {
+      // 500 > 390 and 900 > 844 → fits, scale = 1.0
       final scale = PreviewOverlay.computeScale(
-        const Size(500, 1000),
+        const Size(500, 900),
         const Size(390, 844),
       );
       expect(scale, equals(1.0));
     });
 
-    test('scales down when device is larger than 90% of available space', () {
-      // Device same size as window → neither fits within 90%
-      const available = Size(390, 844);
+    test('returns 1.0 when content area exactly matches emulated size', () {
       const emulated = Size(390, 844);
-      final scale = PreviewOverlay.computeScale(available, emulated);
-      expect(scale, lessThan(1.0));
-      // Should be min(390/390, 844/844) * 0.9 = 0.9
-      expect(scale, closeTo(0.9, 0.001));
+      expect(PreviewOverlay.computeScale(emulated, emulated), equals(1.0));
     });
 
+    test(
+      'scales down to fit when content area is smaller than emulated size',
+      () {
+        // Content area is exactly half the emulated size → scale = 0.5
+        final scale = PreviewOverlay.computeScale(
+          const Size(195, 422),
+          const Size(390, 844),
+        );
+        expect(scale, closeTo(0.5, 0.001));
+      },
+    );
+
     test('scale is bounded by the tighter dimension', () {
-      // Width fits (200 <= 400 * 0.9 = 360) but height does not (900 > 600 * 0.9 = 540)
-      const available = Size(400, 600);
-      const emulated = Size(200, 900);
-      final scale = PreviewOverlay.computeScale(available, emulated);
-      // min(400/200, 600/900) * 0.9 = min(2.0, 0.667) * 0.9 = 0.6
-      expect(scale, closeTo(0.6, 0.001));
+      // Width fits (400 > 200) but height does not (600 < 900)
+      // → min(400/200, 600/900) = min(2.0, 0.667) → clamped to 0.667
+      final scale = PreviewOverlay.computeScale(
+        const Size(400, 600),
+        const Size(200, 900),
+      );
+      expect(scale, closeTo(0.667, 0.001));
     });
   });
 }


### PR DESCRIPTION
Replaces the old 90%-margin scale logic with a layout that reserves the bottom toolbar strip and scales content to fill the rest.

- `_kToolbarAreaHeight = 40` carved out at bottom via `Positioned(bottom: _kToolbarAreaHeight)` — device frame is centered and letterboxed within it
- `computeScale(contentArea, emulated)`: `min(w/W, h/H).clamp(0, 1)` — fills the content area, never upscales, no arbitrary margin
- Device frame sized directly as `SizedBox(emulated * scale)` — no `Transform.scale` needed since `ScreenClipWidget` fills its bounds
- `_kToolbarAreaHeight` matches the same constant in `window_manager_sizing_service.dart` so the window sized by step 4.4 produces a content area exactly equal to the emulated logical size at scale = 1.0