### PR TITLE
Fix screen clipping: use ClipPath to actually clip the child widget

### DIFF
--- a/lib/src/frame/screen_clip_painter.dart
+++ b/lib/src/frame/screen_clip_painter.dart
@@ -37,33 +37,43 @@ class ScreenClipPainter extends CustomPainter {
     return Offset.zero & painterSize;
   }
 
+  /// Returns the clip path for [size], [profile], and [orientation].
+  ///
+  /// The path is the intersection of the rounded screen rect and the inverse
+  /// of the cutout region — i.e. the area where app content should be visible.
+  /// Used by [ScreenClipWidget] to clip the child widget tree.
+  static Path buildClipPath(
+    Size size,
+    DeviceProfile profile,
+    DeviceOrientation orientation,
+  ) {
+    final screenRect = Offset.zero & size;
+    final radius = Radius.circular(profile.screenCornerRadius);
+    final screenRRect = RRect.fromRectAndRadius(screenRect, radius);
+    final screenPath = Path()..addRRect(screenRRect);
+
+    final cutout = profile.cutoutForOrientation(orientation);
+    if (cutout is NoCutout) return screenPath;
+
+    final cutoutPath = _buildCutoutPath(cutout, screenRect);
+    return Path.combine(PathOperation.difference, screenPath, cutoutPath);
+  }
+
   @override
   void paint(Canvas canvas, Size size) {
     final screenRect = Offset.zero & size;
     final radius = Radius.circular(profile.screenCornerRadius);
     final screenRRect = RRect.fromRectAndRadius(screenRect, radius);
 
-    // 1. Clip to rounded screen corners.
+    // Clip to rounded screen corners, then fill with black. This black fill
+    // is visible in the cutout region (and as a backing colour) because the
+    // child's ClipPath — applied by ScreenClipWidget — subtracts the cutout
+    // area from the child, letting this fill show through.
     canvas.clipRRect(screenRRect);
-
-    // 2. Fill with black — this becomes the background behind app content and
-    //    also the fill colour visible in the cutout region after step 3.
     canvas.drawRect(screenRect, Paint()..color = _kScreenColor);
-
-    // 3. For non-NoCutout devices, further restrict the clip so that app
-    //    content cannot paint inside the camera housing area. The black fill
-    //    from step 2 remains visible there.
-    final cutout = profile.cutoutForOrientation(orientation);
-    if (cutout is! NoCutout) {
-      final screenPath = Path()..addRRect(screenRRect);
-      final cutoutPath = _buildCutoutPath(cutout, screenRect);
-      canvas.clipPath(
-        Path.combine(PathOperation.difference, screenPath, cutoutPath),
-      );
-    }
   }
 
-  Path _buildCutoutPath(ScreenCutout cutout, Rect screenRect) {
+  static Path _buildCutoutPath(ScreenCutout cutout, Rect screenRect) {
     return switch (cutout) {
       NoCutout() => Path(),
       NotchCutout(:final size, :final topOffset) =>

--- a/lib/src/frame/screen_clip_widget.dart
+++ b/lib/src/frame/screen_clip_widget.dart
@@ -5,10 +5,11 @@ import 'screen_clip_painter.dart';
 
 /// Clips [child] to the device screen shape — rounded corners and cutout.
 ///
-/// Uses [LayoutBuilder] to fill the available space and positions [child] to
-/// fill the full bounds. The canvas clip (rounded corners minus cutout) is
-/// applied by [ScreenClipPainter], so child pixels are physically absent inside
-/// both the corner regions and the camera housing area.
+/// [ScreenClipPainter] draws a black background fill clipped to the rounded
+/// screen rect (visible behind app content and inside the cutout region).
+/// A [ClipPath] widget applies the same geometry — rounded corners minus
+/// cutout — to the child widget tree, so app pixels are physically absent
+/// inside the corner regions and the camera housing area.
 ///
 /// This widget does **not** perform any metric spoofing — it is purely
 /// cosmetic. Metric spoofing happens in the binding layer.
@@ -33,7 +34,27 @@ class ScreenClipWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return CustomPaint(
       painter: ScreenClipPainter(profile: profile, orientation: orientation),
-      child: child,
+      child: ClipPath(
+        clipper: _ScreenClipper(profile: profile, orientation: orientation),
+        child: child,
+      ),
     );
   }
+}
+
+/// [CustomClipper] that clips to the device screen shape: a rounded rect with
+/// the camera cutout region subtracted.
+class _ScreenClipper extends CustomClipper<Path> {
+  _ScreenClipper({required this.profile, required this.orientation});
+
+  final DeviceProfile profile;
+  final DeviceOrientation orientation;
+
+  @override
+  Path getClip(Size size) =>
+      ScreenClipPainter.buildClipPath(size, profile, orientation);
+
+  @override
+  bool shouldReclip(_ScreenClipper old) =>
+      old.profile != profile || old.orientation != orientation;
 }


### PR DESCRIPTION
The rounded-corner and cutout clipping was silently broken for all devices.

Flutter wraps `CustomPainter.paint()` in `canvas.save()/restore()`, so `clipRRect`/`clipPath` calls inside the painter only affect the painter's own drawing — they are fully restored before child widgets render. The child app was never clipped to the screen shape.

- Add `ScreenClipPainter.buildClipPath()` static method that builds the combined clip path (rounded rect minus cutout)
- Wrap the child in `ClipPath` + `_ScreenClipper` in `ScreenClipWidget`; the clipper delegates to `buildClipPath()`
- Simplify `ScreenClipPainter.paint()` — now only responsible for the black background fill (the cutout area stays black because the child is clipped away there, letting the fill show through)