### PR TITLE
Add title bar height to window size to eliminate letterboxing

### DIFF
--- a/lib/src/window/window_manager_sizing_service.dart
+++ b/lib/src/window/window_manager_sizing_service.dart
@@ -28,7 +28,12 @@ class WindowManagerSizingService implements WindowSizingService {
   ) async {
     await _ready;
 
-    final target = computeTargetSize(profile, orientation);
+    final titleBarHeight = await windowManager.getTitleBarHeight();
+    final emulated = computeTargetSize(profile, orientation);
+    // The window size includes the title bar; Flutter's content area is
+    // window height minus the title bar. Add it back so the content area
+    // exactly matches the emulated device height.
+    final target = ui.Size(emulated.width, emulated.height + titleBarHeight);
     final screen = _screenLogicalSize();
 
     final clamped = ui.Size(


### PR DESCRIPTION
`windowManager.setSize()` sets the full window size including the macOS title bar, so the Flutter content area is `window height − title bar height`. This caused the content area to be slightly shorter than the emulated device height, producing letterboxing on a correctly-sized window.

- Fetch `getTitleBarHeight()` in `applyProfile` and add it to the target height before calling `setSize`.
- `computeTargetSize` is unchanged — it still returns the pure emulated size, keeping it testable without a real window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)