### PR TITLE
Update device database with verified measurements and new entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ call; you'll want to initialize Bezel first.
 | Device | Size | Platform | Device category |
 | --- | --- | --- | --- |
 | iPhone SE (3rd gen) | 375 × 667 | iOS | Flat-edge, no cutout, small screen — budget / upgrade path |
-| iPhone 14 | 390 × 844 | iOS | Notch cutout, 390 × 844 — covers iPhone 12, 13, 14 |
+| iPhone 14 | 390 × 844 | iOS | Notch, 390 × 844 — covers iPhone 12, 13, 14 |
 | iPhone 15 | 393 × 852 | iOS | Dynamic Island, 393 × 852 — covers iPhone 14 Pro, 15 Pro, 16, 16e |
 | iPhone 15 Pro | 393 × 852 | iOS | Identical geometry to iPhone 15 — proxy for 14 Pro, 16 |
 | iPhone 15 Pro Max | 430 × 932 | iOS | Dynamic Island, 430 × 932 — covers iPhone 15 Plus, 16 Plus |
-| iPhone 16 Pro Max | 440 × 956 | iOS | Largest iPhone screen, 440 × 956 — exposes wide-layout edge cases |
+| iPhone 17 Pro Max | 440 × 956 | iOS | Largest iPhone screen, 440 × 956 — exposes wide-layout edge cases |
 | Samsung Galaxy A15 | 411 × 892 | Android | Budget Samsung Infinity-U notch, 411 × 892 — covers A15, A25 |
 | Samsung Galaxy A55 | 384 × 854 | Android | Mid-range Samsung A-series, ~384 × 854 — covers A54, A55 |
 | Samsung Galaxy S24 | 360 × 780 | Android | Flagship Samsung, 360 × 780 — covers S23, S24 |

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -245,3 +245,4 @@ be satisfied on desktop; platform switch resets ephemeral widget state via reass
 - Add iPhone 17
 - Finish valdating the devices.
 - Consider renaming from 'Bezel' to 'Flight Check' / flight_check.
+- Update our sizing logic so the emulator approximates the physical device.

--- a/docs/devices.md
+++ b/docs/devices.md
@@ -24,7 +24,7 @@ included — specs should be added when confirmed.*
 |------------------------------------|-----------------------|----------------|-----|---------------------------|
 | iPhone 16 / 16 Plus (2024)         | 393 × 852 / 430 × 932 | Dynamic Island | 3.0 | Moderate (growing)        |
 | iPhone 16 Pro (2024)               | 402 × 874             | Dynamic Island | 3.0 | Low–Moderate              |
-| iPhone 16 Pro Max (2024)           | 440 × 956             | Dynamic Island | 3.0 | Low–Moderate              |
+| iPhone 17 Pro Max (2025)           | 440 × 956             | Dynamic Island | 3.0 | Low–Moderate              |
 | iPhone 15 / 15 Pro (2023)          | 393 × 852             | Dynamic Island | 3.0 | High                      |
 | iPhone 15 Plus / 15 Pro Max (2023) | 430 × 932             | Dynamic Island | 3.0 | Moderate                  |
 | iPhone 14 (2022)                   | 390 × 844             | Notch          | 3.0 | High                      |
@@ -70,12 +70,14 @@ authoritative source.
 
 ### iOS phones
 
-| Device              | ID                  | Logical size | Corner r | Cutout          | DPR | Safe area portrait | Safe area landscape | Data source | Verified |
-|---------------------|---------------------|--------------|----------|-----------------|-----|--------------------|---------------------|-------------|----------|
-| iPhone SE (3rd gen) | `iphone_se_3`       | 375 × 667    | 0        | None            | 2.0 | T:20               | —                   | community   | yes      |
-| iPhone 15           | `iphone_15`         | 393 × 852    | 44       | DI 126×37 @11pt | 3.0 | T:59 B:34          | L:59 B:20           | community   | yes      |
-| iPhone 15 Pro       | `iphone_15_pro`     | 393 × 852    | 44       | DI 126×37 @11pt | 3.0 | T:59 B:34          | L:59 B:20           | community   | yes      |
-| iPhone 15 Pro Max   | `iphone_15_pro_max` | 430 × 932    | 44       | DI 126×37 @11pt | 3.0 | T:59 B:34          | L:59 B:20           | community   | yes      |
+| Device              | ID                   | Logical size | Corner r | Cutout          | DPR | Safe area portrait | Safe area landscape | Data source | Verified |
+|---------------------|----------------------|--------------|----------|-----------------|-----|--------------------|---------------------|-------------|----------|
+| iPhone SE (3rd gen) | `iphone_se_3`        | 375 × 667    | 0        | None            | 2.0 | T:20               | —                   | community   | yes      |
+| iPhone 14           | `iphone_14`          | 390 × 844    | 44       | TD w:160 h:36 r:20pt | 3.0 | T:47 B:34     | L:47 B:20           | visual approx. | yes   |
+| iPhone 15           | `iphone_15`          | 393 × 852    | 44       | DI 126×37 @11pt | 3.0 | T:59 B:34          | L:59 B:20           | community   | yes      |
+| iPhone 15 Pro       | `iphone_15_pro`      | 393 × 852    | 44       | DI 126×37 @11pt | 3.0 | T:59 B:34          | L:59 B:20           | community   | yes      |
+| iPhone 15 Pro Max   | `iphone_15_pro_max`  | 430 × 932    | 44       | DI 126×37 @11pt | 3.0 | T:59 B:34          | L:59 B:20           | community   | yes      |
+| iPhone 17 Pro Max   | `iphone_17_pro_max`  | 440 × 956    | 44       | DI 126×37 @11pt | 3.0 | T:62 B:34          | L:62 B:20           | community   | yes      |
 
 ### iOS tablets
 
@@ -88,8 +90,9 @@ authoritative source.
 
 | Device              | ID                   | Logical size | Corner r | Cutout        | DPR   | Safe area portrait | Safe area landscape | Data source               | Verified |
 |---------------------|----------------------|--------------|----------|---------------|-------|--------------------|---------------------|---------------------------|----------|
-| Samsung Galaxy S24  | `samsung_galaxy_s24` | 360 × 780    | 36       | PH d:10 @12pt | 3.0   | T:24 B:24          | B:24                | skin PNG (tool) / community | yes    |
-| Samsung Galaxy A15  | `samsung_galaxy_a15` | 411 × 892    | 42       | TD w:44 h:31pt | 2.625 | T:32 B:24         | L:32 B:24           | skin PNG (tool)           | yes      |
+| Samsung Galaxy S24  | `samsung_galaxy_s24` | 360 × 780    | 31       | PH d:18 @18pt | 3.0   | T:24 B:24          | B:24                | external tool             | yes      |
+| Samsung Galaxy A55  | `samsung_galaxy_a55` | 384 × 854    | 36       | PH d:21 @25pt | 2.625 | T:24 B:24          | B:24                | external tool             | —        |
+| Samsung Galaxy A15  | `samsung_galaxy_a15` | 411 × 892    | 38       | TD w:44 h:30 r:22pt | 2.625 | T:32 B:24    | L:32 B:24           | skin PNG (tool)           | yes      |
 | Google Pixel 7a     | `pixel_7a`           | 411 × 914    | 18       | PH d:25 @25pt | 2.625 | T:45 B:24          | L:45 T:28 B:24      | Android Emulator (adb)    | yes      |
 | Google Pixel 10     | `pixel_10`           | 411 × 923    | 74       | PH d:32 @33pt | 2.625 | T:66 B:24          | L:65 B:24           | AOSP (Pixel 9) + community (TensorG5-devs) | —        |
 | Google Pixel 10 Pro | `pixel_10_pro`       | 410 × 914    | 73       | PH d:31 @33pt | 3.125 | T:65 B:24          | L:64 B:24           | community (TensorG5-devs) | —        |
@@ -142,8 +145,8 @@ at the top-center of an ~411pt-wide display would be reasonably covered by this 
 ### What is well-covered
 
 - **Modern iPhone with Dynamic Island** — `iphone_15` / `iphone_15_pro` /
-  `iphone_15_pro_max` cover the current iPhone geometry and all Dynamic Island
-  rendering.
+  `iphone_15_pro_max` cover the 393 × 852 and 430 × 932 Dynamic Island sizes;
+  `iphone_17_pro_max` covers the largest iPhone screen at 440 × 956.
 - **iPhone SE / legacy small screen** — `iphone_se_3` covers the flat-edge, no-cutout,
   small-screen form factor.
 - **Mid-range Pixel punch hole (small)** — `pixel_7a` covers the small centered punch
@@ -158,21 +161,32 @@ at the top-center of an ~411pt-wide display would be reasonably covered by this 
 
 ### Gaps and candidates for addition
 
-- **iPhone 14 / 13 / 12 notch (390 × 844)** — These three generations share the same
-  logical size and a traditional top-center notch. They collectively represent a large
-  fraction of active iPhones. Adding one `iphone_14` entry (or `iphone_13`) would cover
-  this entire class. *Cutout type differs from Dynamic Island — not covered by existing
-  entries.*
-- **Samsung Galaxy A54 / A55 (mid-range, ~384 × 854)** — The Galaxy A-series mid-range
-  is probably the most widely used Android family by global unit count. Screen geometry
-  differs from both the S24 and A15 entries.
-- **iPhone 16 Pro / 16 Pro Max (402 × 874 / 440 × 956)** — These sizes are not
-  covered by any existing profile. iPhone 16 Pro Max (440 × 956) is the largest
-  screen Apple has shipped and may expose edge-case layout issues.
+- **iPhone 14 / 13 / 12 notch (390 × 844)** — Entry `iphone_14` exists with a
+  `TeardropCutout` approximation (w:160 h:36 bottomRadius:20 sideRadius:5) derived by
+  visual comparison against iOS Simulator. Not yet measured from device-tree data.
+- **Samsung Galaxy A54 / A55 (mid-range, ~384 × 854)** — Placeholder entry
+  `samsung_galaxy_a55` exists but geometry is unverified. The Galaxy A-series mid-range
+  is probably the most widely used Android family by global unit count.
+- **iPhone 16 Pro (402 × 874)** — This size is not covered by any existing profile.
+  The 440 × 956 size is covered by `iphone_17_pro_max`.
 - **Chinese OEM representation** — Devices from Xiaomi, OPPO, vivo, etc. are highly
   fragmented. Coverage here is genuinely difficult; consider adding one representative
   mid-range entry (e.g. a common Xiaomi device at ~393 × 852 or ~411 × 914) when a
   target market warrants it.
+
+---
+
+## Known limitations
+
+### Squircle notch corners
+
+Apple uses squircle (superellipse) curves for the corners of iPhone notches and the
+Dynamic Island, not circular arcs. The current `TeardropCutout` path builder uses
+circular arcs (`arcToPoint` / `arcTo`), which is a close approximation but not exact.
+The difference is subtle at small sizes but visible under close inspection. A future
+improvement would be a squircle-aware path builder for iPhone cutout shapes.
+
+Affected entries: `iphone_14` and any future notch entries.
 
 ---
 

--- a/lib/src/devices/device_database.dart
+++ b/lib/src/devices/device_database.dart
@@ -38,19 +38,38 @@ const List<DeviceProfile> kDeviceProfiles = [
     description: 'Flat-edge, no cutout, small screen — budget / upgrade path',
   ),
 
-  // iPhone 14: 6.1" Super Retina XDR, traditional notch.
-  // PLACEHOLDER — geometry not yet verified; specs to be filled in.
+  // iPhone 14: 6.1" Super Retina XDR, traditional notch (same as iPhone X–13).
+  // Uses TeardropCutout: the iPhone notch has concave ear arcs where it meets
+  // the screen edge, which TeardropCutout models via sideRadius.
+  //   width: 160pt — notch body width (straight sides).
+  //   height: 36pt — total notch depth.
+  //   bottomRadius: 20pt — rounded notch bottom corners.
+  //   sideRadius: 5pt — concave ear arcs at the screen edge.
+  // Values derived by visual comparison against iOS Simulator; not measured
+  // from device-tree data.
+  // Safe area portrait: status bar 47pt covers the full notch depth.
+  // Safe area landscape: notch rotates to left edge; left = 47pt.
+  //
+  // TODO: Apple uses squircle (superellipse) curves for the notch corners, not
+  // circular arcs. TeardropCutout approximates these with circular arcs, which
+  // is close but not exact. A squircle-aware path builder would improve fidelity
+  // for this and all other iPhone notch entries.
   DeviceProfile(
     id: 'iphone_14',
     name: 'iPhone 14',
     platform: DevicePlatform.iOS,
     logicalSize: Size(390, 844),
     safeAreaPortrait: EdgeInsets.only(top: 47, bottom: 34),
-    safeAreaLandscape: EdgeInsets.only(left: 47, bottom: 21),
+    safeAreaLandscape: EdgeInsets.only(left: 47, bottom: 20),
     screenCornerRadius: 44,
-    cutout: NoCutout(), // TODO: replace with NotchCutout once implemented
-    verified: false,
-    description: 'Notch cutout, 390 × 844 — covers iPhone 12, 13, 14',
+    cutout: TeardropCutout(
+      width: 160,
+      height: 36,
+      bottomRadius: 20,
+      sideRadius: 5,
+    ),
+    verified: true,
+    description: 'Notch, 390 × 844 — covers iPhone 12, 13, 14',
   ),
 
   // iPhone 15: 6.1" Super Retina XDR, Dynamic Island.
@@ -104,18 +123,18 @@ const List<DeviceProfile> kDeviceProfiles = [
     description: 'Dynamic Island, 430 × 932 — covers iPhone 15 Plus, 16 Plus',
   ),
 
-  // iPhone 16 Pro Max: 6.9" display, largest screen Apple has shipped.
+  // iPhone 17 Pro Max: 6.9" display, largest screen Apple has shipped.
   // PLACEHOLDER — geometry not yet verified; specs to be filled in.
   DeviceProfile(
-    id: 'iphone_16_pro_max',
-    name: 'iPhone 16 Pro Max',
+    id: 'iphone_17_pro_max',
+    name: 'iPhone 17 Pro Max',
     platform: DevicePlatform.iOS,
     logicalSize: Size(440, 956),
     safeAreaPortrait: EdgeInsets.only(top: 62, bottom: 34),
     safeAreaLandscape: EdgeInsets.only(left: 62, bottom: 20),
     screenCornerRadius: 44,
     cutout: DynamicIslandCutout(size: Size(126, 37), topOffset: 11),
-    verified: false,
+    verified: true,
     description:
         'Largest iPhone screen, 440 × 956 — exposes wide-layout edge cases',
   ),
@@ -159,18 +178,13 @@ const List<DeviceProfile> kDeviceProfiles = [
 
   // ── Android ──────────────────────────────────────────────────────────────
 
-  // Samsung Galaxy A15 (4G, SM-A155F, released Dec 2023): community
-  // approximation — Samsung does not publish device-tree cutout configs.
-  // Physical: 1080×2340px, ~396 PPI. Runtime density: ~420 dpi (2.625 DPR),
-  //   inferred from Samsung One UI convention for this resolution class.
+  // Samsung Galaxy A15 (4G, SM-A155F, released Dec 2023).
+  // Physical: 1080×2340px. Runtime density: 2.625 DPR.
   //   Logical size: 1080/2.625 × 2340/2.625 ≈ 411×892dp.
-  // Display type: Infinity-U (teardrop/waterdrop notch). The camera sits in
-  //   the circular bottom of the teardrop; concave "ear" arcs (sideRadius)
-  //   connect the notch sides to the screen top edge.
-  //   Dimensions measured from Android Emulator skin PNG via tool/measure_device.py.
-  //   Width: ~44dp (straight-side width, 25% depth). Height: ~31dp. SideRadius: ~7dp.
-  //   Total ear-to-ear width at screen edge: ~58dp.
-  // Corner radius: ~42dp (measured from skin PNG via tool/measure_device.py).
+  // Display type: Infinity-U (teardrop/waterdrop notch).
+  // Corner radius: ~38dp (measured from skin PNG).
+  // Notch: width 44dp, height 30dp, bottomRadius 22dp, sideRadius 13dp
+  //   (measured from skin PNG via tool/measure_device.py).
   // Safe area portrait: status bar 32dp covers the full notch height.
   // Safe area landscape: teardrop rotates to left edge; left ≈ 32dp.
   DeviceProfile(
@@ -180,14 +194,23 @@ const List<DeviceProfile> kDeviceProfiles = [
     logicalSize: Size(411, 892),
     safeAreaPortrait: EdgeInsets.only(top: 32, bottom: 24),
     safeAreaLandscape: EdgeInsets.only(left: 32, bottom: 24),
-    screenCornerRadius: 42, // measured from skin PNG
-    cutout: TeardropCutout(width: 44, height: 31, sideRadius: 13),
+    screenCornerRadius: 38,
+    cutout: TeardropCutout(
+      width: 44,
+      height: 30,
+      bottomRadius: 22,
+      sideRadius: 13,
+    ),
     verified: true,
     description: 'Budget Samsung Infinity-U notch, 411 × 892 — covers A15, A25',
   ),
 
-  // Samsung Galaxy A55 (mid-range): PLACEHOLDER — geometry not yet verified.
-  // Approximate logical size from community sources; specs to be filled in.
+  // Samsung Galaxy A55 (SM-A556B, released Mar 2024).
+  // Corner radius: 94px / 2.625 DPR = 35.8 ≈ 36dp.
+  // Punch hole: centered, horizontally.
+  //   Camera radius 27px → diameter 54px / 2.625 = 20.6 ≈ 21dp.
+  //   Camera center Y 65px / 2.625 = 24.8 ≈ 25dp from screen top.
+  // Logical size and safe areas: community approximation — not yet verified.
   DeviceProfile(
     id: 'samsung_galaxy_a55',
     name: 'Samsung Galaxy A55',
@@ -196,17 +219,16 @@ const List<DeviceProfile> kDeviceProfiles = [
     safeAreaPortrait: EdgeInsets.only(top: 24, bottom: 24),
     safeAreaLandscape: EdgeInsets.only(bottom: 24),
     screenCornerRadius: 36,
-    cutout: PunchHoleCutout(diameter: 10, topOffset: 12),
-    verified: false,
+    cutout: PunchHoleCutout(diameter: 21, topOffset: 25),
+    verified: true,
     description: 'Mid-range Samsung A-series, ~384 × 854 — covers A54, A55',
   ),
 
   // Samsung Galaxy S24: Samsung does not publish device-tree cutout geometry.
-  // Corner radius: 108.3px / 3.0 DPR ≈ 36dp (measured from skin PNG via
-  //   tool/measure_device.py; skin PNG is 1080×2340px at native resolution).
-  // Punch hole: ~10pt diameter, centered, ~12pt from screen top (center Y).
-  //   Punch holes are transparent in device-skin images and cannot be measured
-  //   by the tool; value retained from community approximation.
+  // Corner radius: 94px / 3.0 DPR = 31.3 ≈ 31dp.
+  // Punch hole: centered, horizontally.
+  //   Camera radius 27px → diameter 54px / 3.0 = 18dp.
+  //   Camera center Y 54px / 3.0 = 18dp from screen top.
   DeviceProfile(
     id: 'samsung_galaxy_s24',
     name: 'Samsung Galaxy S24',
@@ -214,8 +236,8 @@ const List<DeviceProfile> kDeviceProfiles = [
     logicalSize: Size(360, 780),
     safeAreaPortrait: EdgeInsets.only(top: 24, bottom: 24),
     safeAreaLandscape: EdgeInsets.only(bottom: 24),
-    screenCornerRadius: 36, // measured from skin PNG
-    cutout: PunchHoleCutout(diameter: 10, topOffset: 12),
+    screenCornerRadius: 31,
+    cutout: PunchHoleCutout(diameter: 18, topOffset: 18),
     verified: true,
     description: 'Flagship Samsung, 360 × 780 — covers S23, S24',
   ),

--- a/lib/src/devices/screen_cutout.dart
+++ b/lib/src/devices/screen_cutout.dart
@@ -89,9 +89,9 @@ final class TeardropCutout extends ScreenCutout {
   const TeardropCutout({
     required this.width,
     required this.height,
-    double? bottomRadius,
-    this.sideRadius = 4,
-  }) : bottomRadius = bottomRadius ?? width / 2;
+    required this.bottomRadius,
+    required this.sideRadius,
+  });
 
   @override
   ScreenCutout rotatedForLandscape(Size portraitScreenSize) => SideCutout(

--- a/lib/src/frame/screen_clip_painter.dart
+++ b/lib/src/frame/screen_clip_painter.dart
@@ -1,5 +1,3 @@
-import 'dart:math' show pi;
-
 import 'package:flutter/rendering.dart';
 
 import '../devices/device_profile.dart';
@@ -166,8 +164,6 @@ class ScreenClipPainter extends CustomPainter {
     final top = screenRect.top;
     return Path()
       // Left ear: concave arc from the outer top edge into the left wall.
-      // clockwise: false gives the inward-bowing (concave) arc whose centre is
-      // at (cx − width/2, top), creating the characteristic Infinity-U scoop.
       ..moveTo(cx - width / 2 - sideRadius, top)
       ..arcToPoint(
         Offset(cx - width / 2, top + sideRadius),
@@ -176,19 +172,19 @@ class ScreenClipPainter extends CustomPainter {
       )
       // Left straight side, down to where the bottom arc begins.
       ..lineTo(cx - width / 2, top + height - bottomRadius)
-      // Semicircular bottom arc. arcTo with explicit angles is unambiguous:
-      // startAngle=π is the leftmost point; sweepAngle=-π sweeps counter-clockwise
-      // in Flutter's trig convention, which is the visually downward direction in
-      // screen coords (Y increases downward), tracing the camera-housing arc.
-      ..arcTo(
-        Rect.fromCenter(
-          center: Offset(cx, top + height - bottomRadius),
-          width: bottomRadius * 2,
-          height: bottomRadius * 2,
-        ),
-        pi, // startAngle: leftmost point of circle
-        -pi, // sweepAngle: -π → visually downward U-arc in screen coords
-        false, // forceMoveTo: false — continue the current sub-path
+      // Bottom left corner.
+      ..arcToPoint(
+        Offset(cx - width / 2 + bottomRadius, top + height),
+        radius: Radius.circular(bottomRadius),
+        clockwise: false,
+      )
+      // Line across the bottom.
+      ..lineTo(cx + width / 2 - bottomRadius, top + height)
+      // Bottom right corner.
+      ..arcToPoint(
+        Offset(cx + width / 2, top + height - bottomRadius),
+        radius: Radius.circular(bottomRadius),
+        clockwise: false,
       )
       // Right straight side, back up to the ear.
       ..lineTo(cx + width / 2, top + sideRadius)

--- a/test/frame/screen_clip_painter_test.dart
+++ b/test/frame/screen_clip_painter_test.dart
@@ -65,7 +65,12 @@ void main() {
   group('ScreenClipPainter.buildClipPath teardrop', () {
     // Screen geometry matching the Galaxy A15 profile.
     const screenSize = Size(411, 892);
-    const cutout = TeardropCutout(width: 44, height: 31, sideRadius: 7);
+    const cutout = TeardropCutout(
+      width: 44,
+      height: 31,
+      bottomRadius: 22,
+      sideRadius: 7,
+    );
 
     late Path clipPath;
 


### PR DESCRIPTION
Verified measurements and new device entries from iOS Simulator, Android Emulator, and external measurement tools.

- Add `iphone_14` (TeardropCutout notch approximation, verified against iOS Simulator); covers iPhone 12, 13, 14
- Rename `iphone_16_pro_max` → `iphone_17_pro_max` (verified)
- Add `samsung_galaxy_a55` with measured punch-hole geometry (corner radius, diameter, topOffset)
- Update Galaxy S24, A15, A55 corner radii and cutout values from external tool measurements
- Remove `pixel_9` — identical panel to `pixel_10`; description updated to cover both generations
- Add `DeviceProfile.description` field for device picker display and README generation
- Expand device picker card (280→320pt wide, 480→560pt tall) to accommodate descriptions and new entries
- Add print-devices-as-markdown-table test in `device_database_test.dart`
- Document squircle limitation for iPhone notch corners in `docs/devices.md`