### PR TITLE
Update docs and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,7 @@ coverage/
 
 # claude
 .claude/settings.local.json
+.claude/worktrees/
 
+# binary files
 tool/images/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,11 +21,6 @@ Read `DESIGN.md` for the full architecture. Read `docs/PLAN.md` for the current 
 
 - **Dart only.** No generated code, no build_runner, no macros.
 - Follow the [official Dart style guide](https://dart.dev/effective-dart/style).
-- Use `final` everywhere it's applicable. Prefer `const` constructors.
-- Use named parameters for anything with more than two parameters.
-- No `dynamic`. No unnecessary casts. Prefer sealed classes / exhaustive switches for
-  discriminated unions.
-- Doc comments (`///`) on all public API. Brief inline comments for non-obvious logic only.
 - Keep files focused. If a file is growing past ~200 lines, consider whether it should split.
 
 ---
@@ -62,7 +57,7 @@ For tree-shaking guarantees on the binding itself, use conditional imports:
 ```dart
 // flight_check.dart
 export 'src/preview_real.dart'
-  if (dart.library.html) 'src/preview_stub.dart';
+  if (dart.library.io) 'src/preview_stub.dart';
 ```
 
 ---
@@ -87,27 +82,6 @@ flutter test
 
 ## Common Patterns
 
-### Reading the active profile in a widget
-
-```dart
-class _MyWidget extends StatelessWidget {
-  const _MyWidget({required this.controller});
-
-  final PreviewController controller;
-
-  @override
-  Widget build(BuildContext context) {
-    return ListenableBuilder(
-      listenable: controller,
-      builder: (context, _) {
-        final profile = controller.activeProfile;
-        // ...
-      },
-    );
-  }
-}
-```
-
 ### Adding a new device profile
 
 Add an entry to `device_database.dart`. The `DeviceProfile` constructor is the only
@@ -115,16 +89,23 @@ thing that needs to change — no registration, no factory, no codegen. Include 
 noting the data source for cutout geometry and corner radius.
 
 ```dart
+// Pixel 7a (codename: lynx).
+// Cutout: verified against Android Emulator via `adb shell dumpsys display`.
+//   Cutout spec: M 507,66 a 33,33 0 1 0 66,0 33,33 0 1 0 -66,0 Z @left
+//   Circle: center (540, 66)px physical, radius 33px physical.
+//   Diameter: 66px / 2.625 DPR ≈ 25dp; center Y: 66px / 2.625 ≈ 25dp.
+// Corner radius: 47px / 2.625 ≈ 18dp (from roundedCorners in dumpsys output).
+// Safe areas: verified against Android Emulator.
 DeviceProfile(
-  id: 'pixel_8',
-  name: 'Pixel 8',
+  id: 'pixel_7a',
+  name: 'Google Pixel 7a',
   platform: DevicePlatform.android,
   logicalSize: const Size(411, 914),
-  devicePixelRatio: 2.625,
-  safeAreaPortrait: const EdgeInsets.only(top: 48, bottom: 24),
-  safeAreaLandscape: const EdgeInsets.only(left: 24, right: 24, bottom: 16),
-  screenCornerRadius: 25,       // AOSP config_mainDisplayShape, converted from px
-  cutout: PunchHoleCutout(diameter: 11, topOffset: 13),
+  safeAreaPortrait: const EdgeInsets.only(top: 45, bottom: 24),
+  safeAreaLandscape: const EdgeInsets.only(left: 45, top: 28, bottom: 24),
+  screenCornerRadius: 18,
+  cutout: const PunchHoleCutout(diameter: 25, topOffset: 25),
+  description: 'Mid-range Pixel, small punch hole — covers Pixel 7a, 8, 8a',
 ),
 ```
 
@@ -135,8 +116,8 @@ delegate to `_real` for anything not being spoofed:
 
 ```dart
 @override
-double get devicePixelRatio =>
-    _controller.activeProfile?.devicePixelRatio ?? _real.devicePixelRatio;
+ui.Size get physicalSize =>
+    _controller.emulatedLogicalSize * _real.devicePixelRatio;
 ```
 
 ---
@@ -148,8 +129,6 @@ double get devicePixelRatio =>
 - Do not add a plugin/extension system. Keep the surface area small.
 - Do not use `BuildContext` in the binding layer. The binding exists below the widget tree.
 - Do not persist state across sessions (e.g. to shared_preferences). Session memory only.
-- Do not add screenshot functionality in Phase 1 or 2. It's out of scope.
-- Do not add locale / accessibility / text scale overrides. Those are out of scope.
 
 ---
 
@@ -176,19 +155,13 @@ cd example
 flutter run -d macos    # or linux / windows
 ```
 
-To run tests:
+Run these before every commit — all three must be clean:
+
 ```
+dart format .
+flutter analyze
 flutter test
 ```
 
-To check analysis:
-```
-flutter analyze
-```
-
-To check formatting:
-```
-dart format --set-exit-if-changed .
-```
-
-All three must be clean before a change is considered done.
+`dart format` is not optional. Unformatted code will fail CI. Run it even for
+single-line changes.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -49,8 +49,8 @@ A custom `WidgetsFlutterBinding` subclass (`PreviewBinding`) overrides `platform
 with a `PreviewPlatformDispatcher`. This dispatcher wraps the real one and, when a
 `DeviceProfile` is active, substitutes a `PreviewFlutterView` that reports:
 
-- `physicalSize` — the real window's physical pixel dimensions (not spoofed)
-- `devicePixelRatio` — derived from the window's physical size and the emulated logical size
+- `physicalSize` — computed from the emulated logical size × derived DPR
+- `devicePixelRatio` — derived from the available window area and the emulated logical size
   (see DPR section below)
 - `padding` / `viewPadding` / `viewInsets` — the profile's safe area insets
 - Everything else delegated to the real view
@@ -58,6 +58,21 @@ with a `PreviewPlatformDispatcher`. This dispatcher wraps the real one and, when
 This means `_MediaQueryFromView` (Flutter's internal widget that populates `MediaQuery` from
 the view) automatically derives correct `MediaQueryData` without any widget injection. Code
 that bypasses MediaQuery and reads `View.of(context)` directly also sees consistent values.
+
+### Platform Emulation
+
+When a device profile is selected, `PreviewBinding` sets
+`debugDefaultTargetPlatformOverride` to match the profile's platform (iOS or Android). This
+gives correct scroll physics, page transitions, haptic feedback patterns, and theme
+behavior (Material vs Cupertino). The override is applied before `runApp` so that the widget
+tree initializes with the right platform from the start.
+
+Switching profiles triggers a reassemble that resets ephemeral widget state, which is the
+same behavior as hot reload.
+
+Known limitation: text-field keyboard shortcuts may not match the host keyboard when host OS
+and emulated platform differ (e.g. Android profile on macOS); back-navigation expectations
+(Android system back, iOS swipe-back) cannot be satisfied on desktop.
 
 ### Device Pixel Ratio and Window Sizing
 
@@ -105,30 +120,30 @@ issues. DPR has minimal impact on layout:
 
 ### Window Sizing
 
-When the user selects a device or toggles orientation, the window is resized to give the
-app a logical canvas that matches the emulated device's logical dimensions:
+When the user selects a device or toggles orientation, the window is resized to show the
+emulated device at 90% of its logical pixel dimensions:
 
-1. Compute the target window size: emulated logical width × (emulated logical height +
-   toolbar area height). No frame padding — the emulated content fills the window directly.
-2. If the target exceeds the available screen dimensions, reduce to fit.
-3. If the computed window position would place part of it off the right edge or bottom of
+1. Compute the target emulated area: `emulatedLogicalSize × 0.9`.
+2. Compute the full window height: emulated height + toolbar area
+   (`kPreviewSpacing + kToolbarHeight + kPreviewPadding`).
+3. If the window height would exceed 90% of the screen height, scale down proportionally
+   to fit.
+4. If the computed window position would place part of it off the right edge or bottom of
    the screen, reposition the window to stay fully visible.
-4. The effective DPR equals the host DPR (e.g. 2.0 on Retina) since the window width
-   matches the emulated logical width.
 
 **Reactive data flow — the same path for both programmatic and manual resizes:**
 
 ```
 [device selected or orientation toggled]
         ↓
-compute target window size (emulated logical size + toolbar height)
+compute target window size (emulated logical size × 0.9 + toolbar height)
         ↓
 windowManager.setSize(targetLogicalSize)
         ↓                                     ← also fires on manual resize
 [onMetricsChanged on real FlutterView]
         ↓
 PreviewFlutterView recomputes:
-  physicalSize  = realView.physicalSize       (actual render surface, unchanged)
+  physicalSize  = emulatedLogicalSize × devicePixelRatio
   devicePixelRatio = physicalSize.width / emulatedLogicalWidth
         ↓
 Flutter re-lays out app at emulatedLogicalSize with updated DPR
@@ -143,34 +158,35 @@ dimensions — that would break the "I'm emulating this specific device" premise
 
 ### Device Profile Database
 
-A curated, hard-coded list of profiles covering:
+A curated, hard-coded list of profiles selected by market share data: the devices that
+collectively represent the widest share of real-world usage. The goal is not exhaustive
+coverage but a small set of profiles that catches the most layout surprises — different
+screen sizes, aspect ratios, safe area shapes, and cutout styles. Tablets are included for
+the distinct form-factor constraints they impose.
 
-- iPhone SE (small form factor baseline)
-- iPhone 15 / 15 Pro (standard and Pro frame styles)
-- iPhone 15 Pro Max
-- Samsung Galaxy S24
-- Google Pixel 8 / 8 Pro
-- iPad mini
-- iPad (standard)
+See [`docs/devices.md`](docs/devices.md) for the full coverage document: current profiles,
+proxy groups, verification status, and coverage gaps.
 
 Each profile contains:
 
 ```dart
 class DeviceProfile {
-  final String id;
-  final String name;
-  final DevicePlatform platform;        // iOS or android
-  final Size logicalSize;               // portrait logical pixels
-  final double devicePixelRatio;        // nominal device DPR (informational; not reported
-                                        // directly — see DPR section above)
+  final String id;                    // e.g. 'iphone_15'
+  final String name;                  // e.g. 'iPhone 15'
+  final DevicePlatform platform;      // iOS or android
+  final Size logicalSize;             // portrait logical pixels
   final EdgeInsets safeAreaPortrait;
   final EdgeInsets safeAreaLandscape;
-  final double screenCornerRadius;      // device screen corner radius in logical pixels
-  final ScreenCutout cutout;            // geometry of the camera cutout, if any
+  final double screenCornerRadius;    // logical pixels; 0 = square corners
+  final ScreenCutout cutout;          // camera cutout geometry
+  final bool tablet;
+  final String? description;          // short proxy-group description
 }
 ```
 
-Profiles are versioned in the source and updated as new flagship devices ship.
+Profiles are versioned in the source and updated as new flagship devices ship. The
+`devicePixelRatio` is not stored — it is derived from the window dimensions at runtime
+(see DPR section above).
 
 ### Screen Cutout Geometry
 
@@ -186,91 +202,36 @@ top-left corner of the screen area (not the outer device frame). This makes the 
 directly comparable to widget positions in the app.
 
 ```dart
-sealed class ScreenCutout {
-  const ScreenCutout();
+sealed class ScreenCutout { ... }
 
-  /// Returns the cutout geometry appropriate for landscape orientation.
-  /// [portraitScreenSize] is the portrait logical screen size, used to
-  /// compute the position of the cutout after the screen is rotated.
-  ScreenCutout rotatedForLandscape(Size portraitScreenSize) => this;
-}
+final class NoCutout extends ScreenCutout { ... }
+  // Large-bezel devices: iPhone SE, iPads.
 
-/// No cutout — large-bezel devices (iPhone SE, iPads).
-final class NoCutout extends ScreenCutout {
-  const NoCutout();
-}
-
-/// Wide notch at the top center — older iPhones (X–14), some Androids.
 final class NotchCutout extends ScreenCutout {
   final Size size;
-
-  /// Distance from the top edge of the screen area. Usually 0 (flush).
-  final double topOffset;
-
-  const NotchCutout({required this.size, this.topOffset = 0});
-
-  @override
-  ScreenCutout rotatedForLandscape(Size portraitScreenSize) =>
-      // Migrates to the left edge; width and height swap.
-      SideCutout(
-        size: Size(size.height, size.width),
-        centerOffset: portraitScreenSize.height / 2,
-      );
+  final double topOffset;   // Usually 0 (flush to top edge).
 }
+  // Wide notch: iPhone X–14, some Androids.
 
-/// Dynamic Island pill — iPhone 15 and later.
 final class DynamicIslandCutout extends ScreenCutout {
   final Size size;
   final double topOffset;
-
-  const DynamicIslandCutout({required this.size, required this.topOffset});
-
-  @override
-  ScreenCutout rotatedForLandscape(Size portraitScreenSize) =>
-      SideCutout(
-        size: Size(size.height, size.width),
-        centerOffset: portraitScreenSize.height / 2,
-      );
 }
+  // Pill-shaped cutout: iPhone 15 and later.
 
-/// Small circular punch-hole camera — Pixel, Galaxy S series.
 final class PunchHoleCutout extends ScreenCutout {
   final double diameter;
   final double topOffset;
-
-  /// Horizontal center. Null means horizontally centered on the screen.
-  final double? centerX;
-
-  const PunchHoleCutout({
-    required this.diameter,
-    required this.topOffset,
-    this.centerX,
-  });
-
-  @override
-  ScreenCutout rotatedForLandscape(Size portraitScreenSize) {
-    final cx = centerX ?? portraitScreenSize.width / 2;
-    return SideCutout(
-      size: Size(diameter, diameter),
-      centerOffset: cx,
-      edgeOffset: topOffset,
-    );
-  }
+  final double? centerX;    // Null = horizontally centered.
 }
+  // Small circular hole: Pixel, Galaxy S series.
 
-/// A cutout on the left edge, produced by landscape rotation.
-/// Not typically instantiated directly — use rotatedForLandscape().
 final class SideCutout extends ScreenCutout {
   final Size size;
   final double centerOffset;
   final double edgeOffset;
-
-  const SideCutout({
-    required this.size,
-    required this.centerOffset,
-    this.edgeOffset = 0,
-  });
 }
+  // Left-edge cutout produced by landscape rotation; not set directly.
 ```
 
 The screen clip painter uses the cutout geometry in two ways:
@@ -283,8 +244,7 @@ The screen clip painter uses the cutout geometry in two ways:
    physical camera housing or sensor bar.
 
 The screen is also clipped at rounded corners using the profile's `screenCornerRadius`,
-so the background color shows through where a real device's screen would end. This makes
-content near screen edges render honestly without needing a decorative device frame.
+so the background color shows through where a real device's screen would end.
 
 Cutout dimensions are approximate logical-pixel values. For Android (Pixel) devices,
 values are sourced from AOSP device tree configuration (`config_mainBuiltInDisplayCutout`),
@@ -302,29 +262,37 @@ area directly, with the preview background color visible through clipped corners
 **Preview Toolbar** — a compact floating pill widget anchored to the bottom-center of the
 window, below the emulated content area. Contains:
 
-- Device name + chevron → opens device picker popover
+- Device name + chevron → opens device picker
 - Orientation toggle icon button
-- Reassemble (hot reload) icon button
-- Close / pass-through toggle
+- Passthrough mode toggle (hides the device frame entirely)
 
 The toolbar is toggled with `Ctrl+\` (or `Cmd+\` on macOS). When hidden, only the
 keyboard shortcut remains.
 
-**Device Picker Popover** — a lightweight overlay listing available profiles, grouped by
-platform. Keyboard-navigable.
+**Device Picker** — a lightweight overlay card with three tabs (iOS, Android, Tablets)
+listing available profiles. Opens to the tab of the currently active device. Tapping
+outside the card or selecting a device closes it.
 
 **macOS Menu Bar** — on macOS, a `PlatformMenuBar` exposes device selection and orientation
 toggle as native menu items, making the floating toolbar optional.
 
+### Persistence
+
+The last-selected device ID is saved to a JSON file so the same device is restored on next
+launch:
+
+- macOS / Linux: `$HOME/.config/flight_check.json`
+- Windows: `%APPDATA%\flight_check.json`
+
+Persistence failures are silently ignored — it is a convenience feature, not a correctness
+requirement.
+
 ### Hot Reassemble
 
-A "reassemble" button (and keyboard shortcut `Ctrl+R` / `Cmd+R`) calls
-`BindingBase.reassembleApplication()`. This is the in-process rebuild — equivalent to the
-widget rebuild phase of hot reload. It picks up changes to `StatelessWidget.build`,
-theme data, and similar, without requiring Dart source recompilation.
-
-This is distinct from a full hot reload (which requires the `flutter` tooling to recompile
-sources). Full hot reload integration via the VM service is a Phase 3 consideration.
+A keyboard shortcut (`Ctrl+R` / `Cmd+R`) calls `BindingBase.reassembleApplication()`. This
+is the in-process rebuild — equivalent to the widget rebuild phase of hot reload. It picks
+up changes to `StatelessWidget.build`, theme data, and similar, without requiring Dart
+source recompilation.
 
 ---
 
@@ -343,8 +311,6 @@ void main() {
 ```
 
 No wrapper widget is required. The preview activates automatically in debug mode.
-An optional `FlightCheck.configure(...)` call allows setting the default device profile
-and whether the toolbar starts visible.
 
 ---
 
@@ -352,7 +318,7 @@ and whether the toolbar starts visible.
 
 ```
 lib/
-  flight_check.dart   # public API surface
+  flight_check.dart         # public API surface
   src/
     binding/
       preview_binding.dart
@@ -360,19 +326,27 @@ lib/
       preview_flutter_view.dart
     devices/
       device_profile.dart
-      screen_cutout.dart         # ScreenCutout sealed class hierarchy
+      screen_cutout.dart    # ScreenCutout sealed class hierarchy
       device_database.dart
     frame/
-      device_frame_painter.dart  # clips at screen corners and cutouts, fills cutouts black
-      device_frame_widget.dart   # positions child within clipped screen area
+      screen_clip_painter.dart  # clips screen to rounded corners + cutouts, fills black
+      screen_clip_widget.dart   # wraps app content in the screen clip
+    persistence/
+      device_persistence.dart   # saves/loads last-selected device ID
     ui/
+      common.dart               # shared widgets (RaisedSurface neumorphic container)
+      preview_overlay.dart      # orchestrates device clip + toolbar + picker
       preview_toolbar.dart
       device_picker.dart
-      preview_overlay.dart       # orchestrates toolbar + screen clip
+      preview_shortcuts.dart    # keyboard shortcut bindings
+      macos_menu.dart           # PlatformMenuBar for macOS
     window/
       window_sizing_service.dart
       window_manager_sizing_service.dart
-    preview_controller.dart      # ChangeNotifier: active profile, orientation, visibility
+    preview_controller.dart     # ChangeNotifier: active profile, orientation, visibility
+    preview_real.dart           # debug-mode entry point (imported conditionally)
+    preview_stub.dart           # no-op stub for non-desktop targets
+    theme.dart                  # shared colours and layout constants
 ```
 
 ---
@@ -382,7 +356,6 @@ lib/
 | Package | Purpose |
 | --- | --- |
 | `window_manager` | Programmatic window resize / positioning |
-| `flutter_test` (dev) | Reference for TestFlutterView / TestPlatformDispatcher patterns |
 
 Intentionally minimal. No state management packages — `ChangeNotifier` is sufficient.
 The screen clipping is hand-rolled `CustomPainter`, not an image asset dependency.
@@ -396,20 +369,12 @@ The screen clipping is hand-rolled `CustomPainter`, not an image asset dependenc
   but their native rendering surfaces are unaffected
 - Safe area insets are static per profile; dynamic changes (e.g. keyboard appearance) are
   not emulated
-- Cutout dimensions and screen corner radii are approximate values — authoritative AOSP
-  data for Pixels, community-measured for iOS and Samsung; may be off by a few points but
-  sufficient for catching layout surprises before on-device testing
+- Cutout dimensions and screen corner radii are approximate; may be off by a few logical
+  pixels but sufficient for catching layout surprises before on-device testing
 - `MediaQuery.devicePixelRatio` reflects the derived window DPR, not the device's nominal
   DPR; apps that branch on this value may behave differently than on a real device
-- `defaultTargetPlatform` is overridden to match the emulated device's platform, giving
-  correct scroll physics, page transitions, and haptic feedback patterns. Known
-  limitations: text-field keyboard shortcuts may not match the host keyboard when the
-  host OS and emulated platform differ (e.g. Android on macOS); back-navigation
-  assumptions (system back button on Android, swipe-back on iOS) cannot be satisfied on
-  desktop; switching platforms triggers a reassemble that resets ephemeral widget state
-
-## Device coverage
-
-See [`docs/devices.md`](docs/devices.md) for the full device coverage document: top
-devices in market, currently supported profiles with geometry details, proxy groups,
-coverage assessment, and verification status.
+- Text-field keyboard shortcuts may not match the host keyboard when host OS and emulated
+  platform differ (e.g. Android profile on macOS)
+- Back-navigation expectations (Android system back, iOS swipe-back) cannot be satisfied
+  on desktop
+- Switching platforms performs a framework reassemble that resets ephemeral widget state

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -231,7 +231,7 @@ slide vs Material zoom), haptic feedback patterns, text-selection toolbar items,
 the host OS and emulated platform differ; back-navigation platform assumptions cannot
 be satisfied on desktop; platform switch resets ephemeral widget state via reassemble.
 
-### Step 4.8 - General cleanup
+### Step 4.8 — General cleanup
 
 + Find a list of the most commonly used mobile devices and compare that to the
   devices we ship with
@@ -249,3 +249,4 @@ be satisfied on desktop; platform switch resets ephemeral widget state via reass
 + Change the device picker to use a tabbed UI.
 - Update our sizing logic so the emulator approximates the physical device?
 - Improve window position management.
+- Consdier a locale override.


### PR DESCRIPTION
Brings documentation up to date with the current state of the tool.

- DESIGN.md: updated file structure, DeviceProfile fields, window sizing (0.9× scale), platform emulation section, persistence section, tabbed device picker; replaced stale device list with selection rationale + reference to docs/devices.md
- CLAUDE.md: trimmed low-value/obvious content, fixed stale code examples, made `dart format` mandatory and prominent
- docs/PLAN.md: minor wording edits
- .gitignore: add `.claude/worktrees/` and label the `tool/images/` entry