### PR TITLE
Persist device orientation across sessions

### DIFF
--- a/lib/src/binding/preview_binding.dart
+++ b/lib/src/binding/preview_binding.dart
@@ -4,7 +4,7 @@ import 'package:flutter/widgets.dart' show Widget, WidgetsFlutterBinding;
 import 'package:window_manager/window_manager.dart';
 
 import '../devices/device_database.dart';
-import '../devices/device_profile.dart' show DevicePlatform;
+import '../devices/device_profile.dart' show DeviceOrientation, DevicePlatform;
 import '../persistence/device_persistence.dart';
 import '../preview_controller.dart';
 import '../ui/preview_overlay.dart';
@@ -61,11 +61,16 @@ class PreviewBinding extends WidgetsFlutterBinding {
       windowManager.ensureInitialized(),
     );
 
-    // Restore the last-selected device, if any.
+    // Restore the last-selected device and orientation, if any.
     final savedId = loadLastDeviceId();
     if (savedId != null) {
       final profile = DeviceDatabase.findById(savedId);
       if (profile != null) _controller.setProfile(profile);
+    }
+    final savedOrientation = loadLastOrientation();
+    if (savedOrientation != null &&
+        savedOrientation != _controller.orientation) {
+      _controller.toggleOrientation();
     }
 
     // Apply the platform override now, before runApp, so that ThemeData is
@@ -78,14 +83,17 @@ class PreviewBinding extends WidgetsFlutterBinding {
   }
 
   String? _lastSavedProfileId;
+  DeviceOrientation? _lastSavedOrientation;
   DevicePlatform? _lastEmulatedPlatform;
 
   void _onControllerChanged() {
-    // Persist device ID when it changes.
+    // Persist device ID and orientation when either changes.
     final id = _controller.activeProfile.id;
-    if (id != _lastSavedProfileId) {
+    final orientation = _controller.orientation;
+    if (id != _lastSavedProfileId || orientation != _lastSavedOrientation) {
       _lastSavedProfileId = id;
-      saveLastDeviceId(id);
+      _lastSavedOrientation = orientation;
+      saveSettings(deviceId: id, orientation: orientation);
     }
 
     // Update the platform override when the emulated platform changes (e.g.

--- a/lib/src/persistence/device_persistence.dart
+++ b/lib/src/persistence/device_persistence.dart
@@ -1,7 +1,10 @@
 import 'dart:convert';
 import 'dart:io';
 
+import '../devices/device_profile.dart';
+
 const _kDeviceKey = 'lastDevice';
+const _kOrientationKey = 'lastOrientation';
 
 /// Returns the settings file path.
 ///
@@ -41,36 +44,54 @@ Map<String, Object?> _readJson(File file) {
   return {};
 }
 
-/// Reads the last-selected device ID from `.dart_tool/flight_check.json`.
+/// Reads the last-selected device ID from the settings file.
 ///
 /// Returns `null` if the file does not exist, cannot be read, or contains no
 /// device entry. Silently swallows all errors.
 String? loadLastDeviceId() {
   try {
     final file = _settingsFile();
-    if (file == null) {
-      return null;
-    }
+    if (file == null) return null;
     return _readJson(file)[_kDeviceKey] as String?;
   } catch (_) {
     return null;
   }
 }
 
-/// Persists [id] as the last-selected device ID in `.dart_tool/flight_check.json`.
+/// Reads the last-used orientation from the settings file.
+///
+/// Returns `null` if absent or unreadable.
+DeviceOrientation? loadLastOrientation() {
+  try {
+    final file = _settingsFile();
+    if (file == null) return null;
+    final value = _readJson(file)[_kOrientationKey] as String?;
+    return switch (value) {
+      'landscape' => DeviceOrientation.landscape,
+      'portrait' => DeviceOrientation.portrait,
+      _ => null,
+    };
+  } catch (_) {
+    return null;
+  }
+}
+
+/// Persists [id] and [orientation] to the settings file.
 ///
 /// Reads the existing file before writing so that any other fields in the
 /// object are preserved. Silently swallows all errors — persistence failures
 /// should never surface to the user.
-void saveLastDeviceId(String id) {
+void saveSettings({
+  required String deviceId,
+  required DeviceOrientation orientation,
+}) {
   try {
     final file = _settingsFile();
-    if (file == null) {
-      return;
-    }
+    if (file == null) return;
 
     final settings = _readJson(file);
-    settings[_kDeviceKey] = id;
+    settings[_kDeviceKey] = deviceId;
+    settings[_kOrientationKey] = orientation.name;
 
     // The $HOME/.config directory might not exist in some situations (on MacOS,
     // flutter run -d macos is sandboxed into an app specific directory).


### PR DESCRIPTION
Extends session persistence to include device orientation alongside the device ID.

- `saveLastDeviceId()` replaced by `saveSettings(deviceId:, orientation:)` — writes both keys in a single file write
- New `loadLastOrientation()` restores the saved orientation on startup
- Binding saves both values together on any controller change, using a cached `_lastSavedOrientation` to avoid redundant writes