### PR TITLE
Introduce ScreenBorder sealed class; replace screenCornerRadius (step 5.2)

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -259,7 +259,7 @@ Apple uses continuous-curvature (squircle/superellipse) corners on all iPhone
 displays, and the pre-Dynamic Island notch shape is also a squircle-cornered
 Bézier path. This phase improves rendering fidelity for iOS devices.
 
-### Step 5.1 — Update iPhone corner radii in the device database
+### Step 5.1 — Update iPhone corner radii in the device database [done]
 
 The current `screenCornerRadius` values (all 44pt) are a stale community
 approximation. Update them to Simulator-measured tangent points from
@@ -270,7 +270,7 @@ but they are significantly closer to reality.
 - iPhone 15–16 family (393 × 852): 44pt → **61pt**
 - iPhone 17 Pro Max (440 × 956): 44pt → **69pt**
 
-### Step 5.2 — Introduce `ScreenBorder` sealed class; replace `screenCornerRadius`
+### Step 5.2 — Introduce `ScreenBorder` sealed class; replace `screenCornerRadius` [done]
 
 Replace `DeviceProfile.screenCornerRadius: double` with a sealed `ScreenBorder`
 type. Android and iPad devices use `CircularBorder(radius: ...)`. iOS devices

--- a/lib/src/devices/device_database.dart
+++ b/lib/src/devices/device_database.dart
@@ -3,6 +3,7 @@
 import 'package:flutter/painting.dart' show EdgeInsets, Size;
 
 import 'device_profile.dart';
+import 'screen_border.dart';
 import 'screen_cutout.dart';
 
 /// The curated list of supported device profiles.
@@ -65,7 +66,7 @@ final iphone_se_3 = DeviceProfile(
   logicalSize: const Size(375, 667),
   safeAreaPortrait: const EdgeInsets.only(top: 20),
   safeAreaLandscape: EdgeInsets.zero,
-  screenCornerRadius: 0,
+  screenBorder: const CircularBorder(0),
   cutout: const NoCutout(),
   description: 'Flat-edge, no cutout, small screen — budget / upgrade path',
 );
@@ -97,7 +98,7 @@ final iphone_14 = DeviceProfile(
   logicalSize: const Size(390, 844),
   safeAreaPortrait: const EdgeInsets.only(top: 47, bottom: 34),
   safeAreaLandscape: const EdgeInsets.only(left: 47, bottom: 20),
-  screenCornerRadius: 53,
+  screenBorder: const CircularBorder(53),
   cutout: const TeardropCutout(
     width: 160,
     height: 36,
@@ -122,7 +123,7 @@ final iphone_15 = DeviceProfile(
   logicalSize: const Size(393, 852),
   safeAreaPortrait: const EdgeInsets.only(top: 59, bottom: 34),
   safeAreaLandscape: const EdgeInsets.only(left: 59, bottom: 20),
-  screenCornerRadius: 61,
+  screenBorder: const CircularBorder(61),
   cutout: const DynamicIslandCutout(size: Size(126, 37), topOffset: 11),
   description:
       'Dynamic Island, 393 × 852 — proxy for iPhone 14 Pro, 15 Pro, 16, 16e, 17',
@@ -138,7 +139,7 @@ final iphone_15_pro_max = DeviceProfile(
   logicalSize: const Size(430, 932),
   safeAreaPortrait: const EdgeInsets.only(top: 59, bottom: 34),
   safeAreaLandscape: const EdgeInsets.only(left: 59, bottom: 20),
-  screenCornerRadius: 61,
+  screenBorder: const CircularBorder(61),
   cutout: const DynamicIslandCutout(size: Size(126, 37), topOffset: 11),
   description: 'Dynamic Island, 430 × 932 — covers iPhone 15 Plus, 16 Plus',
 );
@@ -156,7 +157,7 @@ final iphone_17 = DeviceProfile(
   logicalSize: const Size(393, 852),
   safeAreaPortrait: const EdgeInsets.only(top: 59, bottom: 34),
   safeAreaLandscape: const EdgeInsets.only(left: 59, bottom: 20),
-  screenCornerRadius: 61,
+  screenBorder: const CircularBorder(61),
   cutout: const DynamicIslandCutout(size: Size(126, 37), topOffset: 11),
   description:
       'Current standard iPhone, 393 × 852 — same geometry as iPhone 15 and 16',
@@ -175,7 +176,7 @@ final iphone_17_pro_max = DeviceProfile(
   logicalSize: const Size(440, 956),
   safeAreaPortrait: const EdgeInsets.only(top: 62, bottom: 34),
   safeAreaLandscape: const EdgeInsets.only(left: 62, bottom: 20),
-  screenCornerRadius: 69,
+  screenBorder: const CircularBorder(69),
   cutout: const DynamicIslandCutout(size: Size(126, 37), topOffset: 11),
   description: 'Largest iPhone screen, 440 × 956',
 );
@@ -198,7 +199,7 @@ final samsung_galaxy_a15 = DeviceProfile(
   logicalSize: const Size(411, 892),
   safeAreaPortrait: const EdgeInsets.only(top: 32, bottom: 24),
   safeAreaLandscape: const EdgeInsets.only(left: 32, bottom: 24),
-  screenCornerRadius: 38,
+  screenBorder: const CircularBorder(38),
   cutout: const TeardropCutout(
     width: 44,
     height: 30,
@@ -221,7 +222,7 @@ final samsung_galaxy_a55 = DeviceProfile(
   logicalSize: const Size(384, 854),
   safeAreaPortrait: const EdgeInsets.only(top: 24, bottom: 24),
   safeAreaLandscape: const EdgeInsets.only(bottom: 24),
-  screenCornerRadius: 36,
+  screenBorder: const CircularBorder(36),
   cutout: const PunchHoleCutout(diameter: 21, topOffset: 25),
   description: 'Mid-range Samsung A-series, ~384 × 854 — covers A54, A55',
 );
@@ -238,7 +239,7 @@ final samsung_galaxy_s24 = DeviceProfile(
   logicalSize: const Size(360, 780),
   safeAreaPortrait: const EdgeInsets.only(top: 24, bottom: 24),
   safeAreaLandscape: const EdgeInsets.only(bottom: 24),
-  screenCornerRadius: 31,
+  screenBorder: const CircularBorder(31),
   cutout: const PunchHoleCutout(diameter: 18, topOffset: 18),
   description: 'Flagship Samsung, 360 × 780 — covers S23, S24',
 );
@@ -257,7 +258,7 @@ final pixel_7a = DeviceProfile(
   logicalSize: const Size(411, 914),
   safeAreaPortrait: const EdgeInsets.only(top: 45, bottom: 24),
   safeAreaLandscape: const EdgeInsets.only(left: 45, top: 28, bottom: 24),
-  screenCornerRadius: 18,
+  screenBorder: const CircularBorder(18),
   cutout: const PunchHoleCutout(diameter: 25, topOffset: 25),
   description: 'Mid-range Pixel, small punch hole — covers Pixel 7a, 8, 8a',
 );
@@ -284,7 +285,7 @@ final pixel_10 = DeviceProfile(
   logicalSize: const Size(411, 923),
   safeAreaPortrait: const EdgeInsets.only(top: 54, bottom: 24),
   safeAreaLandscape: const EdgeInsets.only(left: 54, top: 52, bottom: 24),
-  screenCornerRadius: 74,
+  screenBorder: const CircularBorder(74),
   cutout: const PunchHoleCutout(diameter: 32, topOffset: 33),
   description: 'Large punch hole, 411 × 923 — covers Pixel 9 and 10',
 );
@@ -311,7 +312,7 @@ final pixel_10_pro = DeviceProfile(
   logicalSize: const Size(410, 914),
   safeAreaPortrait: const EdgeInsets.only(top: 65, bottom: 24),
   safeAreaLandscape: const EdgeInsets.only(left: 64, bottom: 24),
-  screenCornerRadius: 73,
+  screenBorder: const CircularBorder(73),
   cutout: const PunchHoleCutout(diameter: 31, topOffset: 33),
   description: 'High-DPR Pixel (3.125), 410 × 914',
 );
@@ -330,7 +331,7 @@ final ipad_mini_a17 = DeviceProfile(
   logicalSize: const Size(744, 1133),
   safeAreaPortrait: const EdgeInsets.only(top: 32, bottom: 20),
   safeAreaLandscape: const EdgeInsets.only(top: 32, bottom: 20),
-  screenCornerRadius: 18,
+  screenBorder: const CircularBorder(18),
   cutout: const NoCutout(),
   tablet: true,
   description: 'Compact iPad, 744 × 1133',
@@ -347,7 +348,7 @@ final ipad_a16 = DeviceProfile(
   logicalSize: const Size(820, 1180),
   safeAreaPortrait: const EdgeInsets.only(top: 32, bottom: 20),
   safeAreaLandscape: const EdgeInsets.only(top: 32, bottom: 20),
-  screenCornerRadius: 18,
+  screenBorder: const CircularBorder(18),
   cutout: const NoCutout(),
   tablet: true,
   description: 'Standard iPad, 820 × 1180',

--- a/lib/src/devices/device_profile.dart
+++ b/lib/src/devices/device_profile.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/painting.dart' show EdgeInsets, Size;
 
+import 'screen_border.dart';
 import 'screen_cutout.dart';
 
 /// The host platform of a device.
@@ -48,12 +49,12 @@ class DeviceProfile {
   /// Safe area insets in landscape orientation.
   final EdgeInsets safeAreaLandscape;
 
-  /// Screen corner radius in logical pixels.
+  /// Screen corner shape used to clip the display to its true rounded outline.
   ///
-  /// Used to clip the device screen to its true rounded-corner shape so the
-  /// preview background shows through where a real display's glass would end.
-  /// A value of 0 means square corners (e.g. iPhone SE, iPads).
-  final double screenCornerRadius;
+  /// A [CircularBorder] with radius 0 means square corners (e.g. iPhone SE).
+  /// All current profiles use [CircularBorder]; [SquircleBorder] will be added
+  /// for iOS devices in Step 5.4 once Bézier control points are available.
+  final ScreenBorder screenBorder;
 
   /// Camera cutout geometry in portrait orientation.
   final ScreenCutout cutout;
@@ -75,7 +76,7 @@ class DeviceProfile {
     required this.logicalSize,
     required this.safeAreaPortrait,
     required this.safeAreaLandscape,
-    required this.screenCornerRadius,
+    required this.screenBorder,
     required this.cutout,
     this.tablet = false,
     this.description,

--- a/lib/src/devices/screen_border.dart
+++ b/lib/src/devices/screen_border.dart
@@ -1,0 +1,22 @@
+/// Models the screen corner shape of a device.
+///
+/// Used by [ScreenClipPainter] to clip the display content to the device's
+/// true screen shape. Currently only [CircularBorder] is used; [SquircleBorder]
+/// will be added in Step 5.4 once Bézier control points are extracted from the
+/// iOS Simulator framebuffer PDFs (see `docs/PLAN.md`).
+sealed class ScreenBorder {
+  const ScreenBorder();
+}
+
+/// Standard circular-arc corner clipping.
+///
+/// Used by all current device profiles. Android and iPad profiles use measured
+/// or community-approximated radii; iOS profiles use Simulator-measured squircle
+/// tangent points as a stand-in for the true squircle path (which is larger than
+/// the equivalent circular arc — see Step 5.4 in `docs/PLAN.md`).
+final class CircularBorder extends ScreenBorder {
+  /// Corner radius in logical pixels. A value of 0 means square corners.
+  final double radius;
+
+  const CircularBorder(this.radius);
+}

--- a/lib/src/frame/screen_clip_painter.dart
+++ b/lib/src/frame/screen_clip_painter.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/rendering.dart';
 
 import '../devices/device_profile.dart';
+import '../devices/screen_border.dart';
 import '../devices/screen_cutout.dart';
 
 // Screen background color (visible before the child paints).
@@ -48,7 +49,7 @@ class ScreenClipPainter extends CustomPainter {
     DeviceOrientation orientation,
   ) {
     final screenRect = Offset.zero & size;
-    final radius = Radius.circular(profile.screenCornerRadius);
+    final radius = _cornerRadius(profile.screenBorder);
     final screenRRect = RRect.fromRectAndRadius(screenRect, radius);
     final screenPath = Path()..addRRect(screenRRect);
 
@@ -62,7 +63,7 @@ class ScreenClipPainter extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
     final screenRect = Offset.zero & size;
-    final radius = Radius.circular(profile.screenCornerRadius);
+    final radius = _cornerRadius(profile.screenBorder);
     final screenRRect = RRect.fromRectAndRadius(screenRect, radius);
 
     // Clip to rounded screen corners, then fill with black. This black fill
@@ -201,4 +202,10 @@ class ScreenClipPainter extends CustomPainter {
   @override
   bool shouldRepaint(ScreenClipPainter oldDelegate) =>
       oldDelegate.profile != profile || oldDelegate.orientation != orientation;
+}
+
+Radius _cornerRadius(ScreenBorder border) {
+  return switch (border) {
+    CircularBorder(:final radius) => Radius.circular(radius),
+  };
 }

--- a/lib/src/ui/preview_overlay.dart
+++ b/lib/src/ui/preview_overlay.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart' show Theme, ThemeData, Brightness;
 import 'package:flutter/widgets.dart';
 
+import '../devices/screen_border.dart';
 import '../frame/screen_clip_widget.dart';
 import '../preview_controller.dart';
 import '../theme.dart';
@@ -76,9 +77,9 @@ class PreviewOverlay extends StatelessWidget {
                                 return Center(
                                   child: RaisedSurface(
                                     borderRadius: BorderRadius.circular(
-                                      controller
-                                          .activeProfile
-                                          .screenCornerRadius,
+                                      _cornerRadiusValue(
+                                        controller.activeProfile.screenBorder,
+                                      ),
                                     ),
                                     height: 6,
                                     child: SizedBox(
@@ -140,4 +141,10 @@ class PreviewOverlay extends StatelessWidget {
         )
         .clamp(0.0, 1.0);
   }
+}
+
+double _cornerRadiusValue(ScreenBorder border) {
+  return switch (border) {
+    CircularBorder(:final radius) => radius,
+  };
 }

--- a/test/devices/device_profile_test.dart
+++ b/test/devices/device_profile_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/painting.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:flight_check/src/devices/device_profile.dart';
+import 'package:flight_check/src/devices/screen_border.dart';
 import 'package:flight_check/src/devices/screen_cutout.dart';
 
 void main() {
@@ -16,7 +17,7 @@ void main() {
       logicalSize: portraitSize,
       safeAreaPortrait: const EdgeInsets.only(top: 59, bottom: 34),
       safeAreaLandscape: const EdgeInsets.only(left: 59, right: 59, bottom: 21),
-      screenCornerRadius: 0,
+      screenBorder: const CircularBorder(0),
       cutout: cutout,
     );
   }

--- a/test/frame/screen_clip_painter_test.dart
+++ b/test/frame/screen_clip_painter_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:flight_check/src/devices/device_database.dart';
 import 'package:flight_check/src/devices/device_profile.dart';
+import 'package:flight_check/src/devices/screen_border.dart';
 import 'package:flight_check/src/devices/screen_cutout.dart';
 import 'package:flight_check/src/frame/screen_clip_painter.dart';
 
@@ -19,7 +20,7 @@ void main() {
       logicalSize: logicalSize,
       safeAreaPortrait: const EdgeInsets.only(top: 59, bottom: 34),
       safeAreaLandscape: const EdgeInsets.only(left: 59, right: 59, bottom: 21),
-      screenCornerRadius: 0,
+      screenBorder: const CircularBorder(0),
       cutout: cutout,
     );
   }


### PR DESCRIPTION
Step 5.2 of the iOS screen geometry fidelity phase (issue #63).

- Adds a new `ScreenBorder` sealed class with a `CircularBorder(radius)` variant
- Replaces `DeviceProfile.screenCornerRadius: double` with `screenBorder: ScreenBorder`
- All 14 device profiles updated to `const CircularBorder(N)`
- The exhaustive switch in `ScreenClipPainter` and `PreviewOverlay` will fail to compile when `SquircleBorder` is added in step 5.4, ensuring no case is missed