### PR TITLE
Implement SquircleBorder and squircle clip path rendering (step 5.4)

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -284,7 +284,7 @@ framebuffer PDF and print the Bézier control points for one corner (top-left),
 normalized to logical points. Also extract the iPhone 14 notch Bézier path from
 the sensor bar PDF.
 
-### Step 5.4 — Populate `SquircleBorder` for iOS devices; implement rendering
+### Step 5.4 — Populate `SquircleBorder` for iOS devices; implement rendering [done]
 
 With control points from step 5.3, populate `SquircleBorder` entries for each
 iPhone family. Implement path building in `ScreenClipPainter`: reflect/rotate

--- a/lib/src/devices/device_database.dart
+++ b/lib/src/devices/device_database.dart
@@ -82,15 +82,12 @@ final iphone_se_3 = DeviceProfile(
 // from device-tree data.
 // Safe area portrait: status bar 47pt covers the full notch depth.
 // Safe area landscape: notch rotates to left edge; left = 47pt.
-// Corner radius: 44pt (community approximation; visually verified against
-// iOS Simulator). Corner radius: 53pt (squircle tangent point from Simulator
-// framebuffer PDF, Xcode 16). Circular-arc rendering with the tangent point
-// produces slightly larger corners than the real device — see Step 5.2 in
-// PLAN.md for the planned squircle rendering upgrade.
+// Corner border: 6-segment squircle Bézier from the Simulator framebuffer PDF
+// (Xcode 16, "iPhone 14", 1170×2532 px, 3× scale).
+//   Top tangent: 390 − 322.54 = 67.46 pt. Side tangent: 67.47 pt.
 //
-// TODO(#63): Apple uses squircle (superellipse) curves for the notch corners.
-// TeardropCutout approximates these with circular arcs. A PathCutout using
-// Bézier segments from the sensor bar PDF would improve fidelity (Step 5.5).
+// TODO(#63): Apple uses squircle curves for the notch corners too. A PathCutout
+// using Bézier segments from the sensor bar PDF would improve fidelity (step 5.5).
 final iphone_14 = DeviceProfile(
   id: 'iphone_14',
   name: 'iPhone 14',
@@ -98,7 +95,49 @@ final iphone_14 = DeviceProfile(
   logicalSize: const Size(390, 844),
   safeAreaPortrait: const EdgeInsets.only(top: 47, bottom: 34),
   safeAreaLandscape: const EdgeInsets.only(left: 47, bottom: 20),
-  screenBorder: const CircularBorder(53),
+  screenBorder: const SquircleBorder(
+    topTangentLength: 67.46,
+    // Segments are relative to the top-right corner (390, 0). Each row is one
+    // cubic: cp1x, cp1y, cp2x, cp2y, x, y.
+    segments: [
+      -63.04,
+      0.00,
+      -57.60,
+      0.02,
+      -53.22,
+      0.16,
+      -48.49,
+      0.32,
+      -43.71,
+      0.65,
+      -39.03,
+      1.48,
+      -29.42,
+      3.18,
+      -20.81,
+      6.90,
+      -13.85,
+      13.85,
+      -6.89,
+      20.81,
+      -3.17,
+      29.43,
+      -1.48,
+      39.03,
+      -0.65,
+      43.71,
+      -0.31,
+      48.50,
+      -0.16,
+      53.22,
+      -0.01,
+      57.60,
+      0.00,
+      63.04,
+      0.00,
+      67.47,
+    ],
+  ),
   cutout: const TeardropCutout(
     width: 160,
     height: 36,
@@ -109,13 +148,13 @@ final iphone_14 = DeviceProfile(
 );
 
 // iPhone 15: 6.1" Super Retina XDR, Dynamic Island.
-// Corner radius: 61pt (squircle tangent point from Simulator framebuffer PDF,
-// Xcode 16). Circular-arc rendering with the tangent point produces slightly
-// larger corners than the real device — see Step 5.2 in PLAN.md for the
-// planned squircle rendering upgrade.
 // Dynamic Island: ~126×37pt pill, ~11pt from screen top
 //   (community measurement; hardware cutout, not the expanded software UI).
 // Safe-area: useyourloaf.com iPhone 15 Screen Sizes
+// Corner border: 6-segment squircle Bézier from the Simulator framebuffer PDF
+// (Xcode 16, "iPhone 15", 1179×2556 px, 3× scale).
+//   Top tangent: 393 − 318.35 = 74.65 pt. Side tangent: 73.80 pt.
+//   Same corner shape as iPhone 14 Pro, 15 Pro, 16, 16e, and 17.
 final iphone_15 = DeviceProfile(
   id: 'iphone_15',
   name: 'iPhone 15',
@@ -123,14 +162,59 @@ final iphone_15 = DeviceProfile(
   logicalSize: const Size(393, 852),
   safeAreaPortrait: const EdgeInsets.only(top: 59, bottom: 34),
   safeAreaLandscape: const EdgeInsets.only(left: 59, bottom: 20),
-  screenBorder: const CircularBorder(61),
+  screenBorder: const SquircleBorder(
+    topTangentLength: 74.65,
+    // Segments relative to top-right corner (393, 0). Each row: cp1x, cp1y,
+    // cp2x, cp2y, x, y.
+    segments: [
+      -70.06,
+      0.00,
+      -65.48,
+      0.02,
+      -60.89,
+      0.19,
+      -55.47,
+      0.39,
+      -50.10,
+      0.80,
+      -44.74,
+      1.80,
+      -33.93,
+      3.82,
+      -24.09,
+      8.19,
+      -16.14,
+      16.14,
+      -8.19,
+      24.09,
+      -3.82,
+      33.92,
+      -1.80,
+      44.74,
+      -0.80,
+      50.10,
+      -0.39,
+      55.47,
+      -0.19,
+      60.90,
+      -0.03,
+      65.20,
+      0.00,
+      69.50,
+      0.00,
+      73.80,
+    ],
+  ),
   cutout: const DynamicIslandCutout(size: Size(126, 37), topOffset: 11),
   description:
       'Dynamic Island, 393 × 852 — proxy for iPhone 14 Pro, 15 Pro, 16, 16e, 17',
 );
 
 // iPhone 15 Pro Max: 6.7" variant; same DI cutout geometry.
-// Corner radius: 61pt (same Simulator-measured tangent point as iphone_15).
+// Corner border: 6-segment squircle Bézier from the Simulator framebuffer PDF
+// (Xcode 16, "iPhone 15 Plus", 1290×2796 px, 3× scale).
+//   Top tangent: 430 − 355.35 = 74.65 pt. Side tangent: 75.90 pt.
+//   Same tangent length as the 393 pt wide family; corner shape is identical.
 // Source: useyourloaf.com, iosresolution.com
 final iphone_15_pro_max = DeviceProfile(
   id: 'iphone_15_pro_max',
@@ -139,7 +223,49 @@ final iphone_15_pro_max = DeviceProfile(
   logicalSize: const Size(430, 932),
   safeAreaPortrait: const EdgeInsets.only(top: 59, bottom: 34),
   safeAreaLandscape: const EdgeInsets.only(left: 59, bottom: 20),
-  screenBorder: const CircularBorder(61),
+  screenBorder: const SquircleBorder(
+    topTangentLength: 74.65,
+    // Segments relative to top-right corner (430, 0). Each row: cp1x, cp1y,
+    // cp2x, cp2y, x, y.
+    segments: [
+      -70.06,
+      0.00,
+      -65.48,
+      0.02,
+      -60.89,
+      0.19,
+      -55.47,
+      0.39,
+      -50.10,
+      0.80,
+      -44.74,
+      1.80,
+      -33.93,
+      3.82,
+      -24.09,
+      8.19,
+      -16.14,
+      16.14,
+      -8.19,
+      24.09,
+      -3.82,
+      33.92,
+      -1.80,
+      44.74,
+      -0.80,
+      50.10,
+      -0.39,
+      55.47,
+      -0.19,
+      60.90,
+      0.00,
+      65.90,
+      0.00,
+      70.90,
+      0.00,
+      75.90,
+    ],
+  ),
   cutout: const DynamicIslandCutout(size: Size(126, 37), topOffset: 11),
   description: 'Dynamic Island, 430 × 932 — covers iPhone 15 Plus, 16 Plus',
 );
@@ -147,7 +273,7 @@ final iphone_15_pro_max = DeviceProfile(
 // iPhone 17: 6.1" display, same screen geometry as iPhone 16 and iPhone 15.
 // Apple has held the 393×852 logical size constant from iPhone 14 Pro through
 // iPhone 17; safe-area and DI cutout values are unchanged from iphone_15.
-// Corner radius: 61pt (same Simulator-measured tangent point as iphone_15).
+// Corner border: same Simulator-extracted squircle shape as iphone_15.
 // Listed separately so the current flagship appears in the device picker.
 // Source: iosresolution.com, useyourloaf.com
 final iphone_17 = DeviceProfile(
@@ -157,7 +283,48 @@ final iphone_17 = DeviceProfile(
   logicalSize: const Size(393, 852),
   safeAreaPortrait: const EdgeInsets.only(top: 59, bottom: 34),
   safeAreaLandscape: const EdgeInsets.only(left: 59, bottom: 20),
-  screenBorder: const CircularBorder(61),
+  screenBorder: const SquircleBorder(
+    topTangentLength: 74.65,
+    // Same corner shape as iphone_15 (393 pt wide, same Simulator PDF).
+    segments: [
+      -70.06,
+      0.00,
+      -65.48,
+      0.02,
+      -60.89,
+      0.19,
+      -55.47,
+      0.39,
+      -50.10,
+      0.80,
+      -44.74,
+      1.80,
+      -33.93,
+      3.82,
+      -24.09,
+      8.19,
+      -16.14,
+      16.14,
+      -8.19,
+      24.09,
+      -3.82,
+      33.92,
+      -1.80,
+      44.74,
+      -0.80,
+      50.10,
+      -0.39,
+      55.47,
+      -0.19,
+      60.90,
+      -0.03,
+      65.20,
+      0.00,
+      69.50,
+      0.00,
+      73.80,
+    ],
+  ),
   cutout: const DynamicIslandCutout(size: Size(126, 37), topOffset: 11),
   description:
       'Current standard iPhone, 393 × 852 — same geometry as iPhone 15 and 16',
@@ -165,8 +332,9 @@ final iphone_17 = DeviceProfile(
 
 // iPhone 17 Pro Max: 6.9" display, largest screen Apple has shipped.
 // Logical size 440×956pt confirmed at launch (Sept 2025).
-// Corner radius: 69pt (squircle tangent point from Simulator framebuffer PDF).
-// See Step 5.2 in PLAN.md for the planned squircle rendering upgrade.
+// Corner border: 6-segment squircle Bézier from the Simulator framebuffer PDF
+// (Xcode 16, "iPhone 17 Pro Max", 1320×2868 px, 3× scale).
+//   Top tangent: 440 − 354.84 = 85.16 pt. Side tangent: 85.00 pt.
 // DI cutout and safe-area values extrapolated from the iPhone 15 Pro Max family.
 // Source: iosresolution.com, community measurements
 final iphone_17_pro_max = DeviceProfile(
@@ -176,7 +344,49 @@ final iphone_17_pro_max = DeviceProfile(
   logicalSize: const Size(440, 956),
   safeAreaPortrait: const EdgeInsets.only(top: 62, bottom: 34),
   safeAreaLandscape: const EdgeInsets.only(left: 62, bottom: 20),
-  screenBorder: const CircularBorder(69),
+  screenBorder: const SquircleBorder(
+    topTangentLength: 85.16,
+    // Segments relative to top-right corner (440, 0). Each row: cp1x, cp1y,
+    // cp2x, cp2y, x, y.
+    segments: [
+      -79.79,
+      0.00,
+      -74.41,
+      0.02,
+      -69.04,
+      0.22,
+      -62.88,
+      0.44,
+      -56.80,
+      0.91,
+      -50.73,
+      2.04,
+      -38.46,
+      4.33,
+      -27.30,
+      9.29,
+      -18.30,
+      18.30,
+      -9.29,
+      27.31,
+      -4.33,
+      38.46,
+      -2.04,
+      50.73,
+      -0.91,
+      56.80,
+      -0.44,
+      62.88,
+      -0.21,
+      69.03,
+      -0.02,
+      74.35,
+      0.00,
+      79.68,
+      0.00,
+      85.00,
+    ],
+  ),
   cutout: const DynamicIslandCutout(size: Size(126, 37), topOffset: 11),
   description: 'Largest iPhone screen, 440 × 956',
 );

--- a/lib/src/devices/screen_border.dart
+++ b/lib/src/devices/screen_border.dart
@@ -1,22 +1,57 @@
 /// Models the screen corner shape of a device.
 ///
 /// Used by [ScreenClipPainter] to clip the display content to the device's
-/// true screen shape. Currently only [CircularBorder] is used; [SquircleBorder]
-/// will be added in Step 5.4 once Bézier control points are extracted from the
-/// iOS Simulator framebuffer PDFs (see `docs/PLAN.md`).
+/// true screen shape.
 sealed class ScreenBorder {
   const ScreenBorder();
 }
 
 /// Standard circular-arc corner clipping.
 ///
-/// Used by all current device profiles. Android and iPad profiles use measured
-/// or community-approximated radii; iOS profiles use Simulator-measured squircle
-/// tangent points as a stand-in for the true squircle path (which is larger than
-/// the equivalent circular arc — see Step 5.4 in `docs/PLAN.md`).
+/// Used for Android and iPad profiles with measured or community-approximated
+/// radii. A radius of 0 means square corners.
 final class CircularBorder extends ScreenBorder {
   /// Corner radius in logical pixels. A value of 0 means square corners.
   final double radius;
 
   const CircularBorder(this.radius);
+}
+
+/// Squircle (continuous-curvature) corner clipping for iPhone displays.
+///
+/// Apple uses superellipse curves rather than circular arcs for iPhone screen
+/// corners. This class stores the exact Bézier control points extracted from
+/// the iOS Simulator framebuffer PDFs (`tool/extract_simdevicetype.dart`).
+///
+/// ## Coordinate convention
+///
+/// [segments] describes the top-right corner in Flutter logical points with
+/// the corner position (logW, 0) as the origin. The path goes from
+/// (−[topTangentLength], 0) on the top edge to (0, [sideTangentLength]) on
+/// the right edge. Each segment is 6 doubles: cp1x, cp1y, cp2x, cp2y, x, y.
+///
+/// The painter reflects and rotates this one corner to build all four corners
+/// of the full screen clip path. See [ScreenClipPainter] for details.
+final class SquircleBorder extends ScreenBorder {
+  /// Distance from the top-right corner to the tangent point on the top edge
+  /// (logical pixels, portrait). Equals screenWidth − tangentX.
+  final double topTangentLength;
+
+  /// Cubic Bézier segments for the top-right corner, as a flat list of
+  /// 6 × N doubles. Each group of 6 is: cp1x, cp1y, cp2x, cp2y, x, y,
+  /// all relative to the corner position (logW, 0) in logical pixels.
+  ///
+  /// The path begins at (−[topTangentLength], 0) and ends at
+  /// (0, [sideTangentLength]).
+  final List<double> segments;
+
+  const SquircleBorder({
+    required this.topTangentLength,
+    required this.segments,
+  });
+
+  /// Distance from the top-right corner to the tangent point on the right
+  /// edge (logical pixels, portrait). Derived from the last y value in
+  /// [segments].
+  double get sideTangentLength => segments[segments.length - 1];
 }

--- a/lib/src/frame/screen_clip_painter.dart
+++ b/lib/src/frame/screen_clip_painter.dart
@@ -11,9 +11,9 @@ const _kScreenColor = Color(0xFF000000);
 /// regions with black so that app content is physically absent there.
 ///
 /// The painter fills the entire painter bounds. The canvas is first clipped
-/// to the rounded-corner screen shape (using [DeviceProfile.screenCornerRadius]),
-/// then the cutout region is subtracted, leaving only the usable screen area
-/// exposed to child widgets.
+/// to the screen corner shape (circular arc or squircle depending on the
+/// profile's [ScreenBorder]), then the cutout region is subtracted, leaving
+/// only the usable screen area exposed to child widgets.
 ///
 /// [ScreenClipWidget] uses this painter and positions its child to fill the
 /// same full bounds.
@@ -40,163 +40,31 @@ class ScreenClipPainter extends CustomPainter {
 
   /// Returns the clip path for [size], [profile], and [orientation].
   ///
-  /// The path is the intersection of the rounded screen rect and the inverse
-  /// of the cutout region — i.e. the area where app content should be visible.
+  /// The path is the intersection of the screen shape and the inverse of the
+  /// cutout region — i.e. the area where app content should be visible.
   /// Used by [ScreenClipWidget] to clip the child widget tree.
   static Path buildClipPath(
     Size size,
     DeviceProfile profile,
     DeviceOrientation orientation,
   ) {
-    final screenRect = Offset.zero & size;
-    final radius = _cornerRadius(profile.screenBorder);
-    final screenRRect = RRect.fromRectAndRadius(screenRect, radius);
-    final screenPath = Path()..addRRect(screenRRect);
-
+    final screenPath = _buildScreenPath(size, profile.screenBorder);
     final cutout = profile.cutoutForOrientation(orientation);
     if (cutout is NoCutout) return screenPath;
 
-    final cutoutPath = _buildCutoutPath(cutout, screenRect);
+    final cutoutPath = _buildCutoutPath(cutout, Offset.zero & size);
     return Path.combine(PathOperation.difference, screenPath, cutoutPath);
   }
 
   @override
   void paint(Canvas canvas, Size size) {
-    final screenRect = Offset.zero & size;
-    final radius = _cornerRadius(profile.screenBorder);
-    final screenRRect = RRect.fromRectAndRadius(screenRect, radius);
+    final screenPath = _buildScreenPath(size, profile.screenBorder);
 
-    // Clip to rounded screen corners, then fill with black. This black fill
-    // is visible in the cutout region (and as a backing colour) because the
-    // child's ClipPath — applied by ScreenClipWidget — subtracts the cutout
-    // area from the child, letting this fill show through.
-    canvas.clipRRect(screenRRect);
-    canvas.drawRect(screenRect, Paint()..color = _kScreenColor);
-  }
-
-  static Path _buildCutoutPath(ScreenCutout cutout, Rect screenRect) {
-    return switch (cutout) {
-      NoCutout() => Path(),
-      TeardropCutout(
-        :final width,
-        :final height,
-        :final bottomRadius,
-        :final sideRadius,
-      ) =>
-        _buildTeardropPath(
-          screenRect,
-          width: width,
-          height: height,
-          bottomRadius: bottomRadius,
-          sideRadius: sideRadius,
-        ),
-      NotchCutout(:final size, :final topOffset) =>
-        Path()..addRRect(
-          RRect.fromRectAndRadius(
-            Rect.fromLTWH(
-              screenRect.left + (screenRect.width - size.width) / 2,
-              screenRect.top + topOffset,
-              size.width,
-              size.height,
-            ),
-            const Radius.circular(4),
-          ),
-        ),
-      DynamicIslandCutout(:final size, :final topOffset) =>
-        Path()..addRRect(
-          RRect.fromRectAndRadius(
-            Rect.fromLTWH(
-              screenRect.left + (screenRect.width - size.width) / 2,
-              screenRect.top + topOffset,
-              size.width,
-              size.height,
-            ),
-            // Pill shape — fully rounded on the short axis.
-            Radius.circular(size.height / 2),
-          ),
-        ),
-      PunchHoleCutout(:final diameter, :final topOffset, :final centerX) =>
-        Path()..addOval(
-          Rect.fromCenter(
-            center: Offset(
-              centerX != null
-                  ? screenRect.left + centerX
-                  : screenRect.center.dx,
-              screenRect.top + topOffset,
-            ),
-            width: diameter,
-            height: diameter,
-          ),
-        ),
-      SideCutout(
-        :final size,
-        :final centerOffset,
-        :final edgeOffset,
-        :final cornerRadius,
-      ) =>
-        Path()..addRRect(
-          RRect.fromRectAndRadius(
-            Rect.fromLTWH(
-              screenRect.left + edgeOffset,
-              screenRect.top + centerOffset - size.height / 2,
-              size.width,
-              size.height,
-            ),
-            Radius.circular(cornerRadius),
-          ),
-        ),
-    };
-  }
-
-  // Builds the clip path for a TeardropCutout centred at the top of
-  // [screenRect]. The shape is a narrow U with:
-  //   - concave "ear" arcs (radius [sideRadius]) at the top corners, curving
-  //     outward into the screen area
-  //   - straight sides running down from the ears
-  //   - a semicircular bottom arc (radius [bottomRadius]) surrounding the camera
-  static Path _buildTeardropPath(
-    Rect screenRect, {
-    required double width,
-    required double height,
-    required double bottomRadius,
-    required double sideRadius,
-  }) {
-    final cx = screenRect.left + screenRect.width / 2;
-    final top = screenRect.top;
-    return Path()
-      // Left ear: concave arc from the outer top edge into the left wall.
-      ..moveTo(cx - width / 2 - sideRadius, top)
-      ..arcToPoint(
-        Offset(cx - width / 2, top + sideRadius),
-        radius: Radius.circular(sideRadius),
-        clockwise: true,
-      )
-      // Left straight side, down to where the bottom arc begins.
-      ..lineTo(cx - width / 2, top + height - bottomRadius)
-      // Bottom left corner.
-      ..arcToPoint(
-        Offset(cx - width / 2 + bottomRadius, top + height),
-        radius: Radius.circular(bottomRadius),
-        clockwise: false,
-      )
-      // Line across the bottom.
-      ..lineTo(cx + width / 2 - bottomRadius, top + height)
-      // Bottom right corner.
-      ..arcToPoint(
-        Offset(cx + width / 2, top + height - bottomRadius),
-        radius: Radius.circular(bottomRadius),
-        clockwise: false,
-      )
-      // Right straight side, back up to the ear.
-      ..lineTo(cx + width / 2, top + sideRadius)
-      // Right ear: symmetric concave arc back to the top edge.
-      ..arcToPoint(
-        Offset(cx + width / 2 + sideRadius, top),
-        radius: Radius.circular(sideRadius),
-        clockwise: true,
-      )
-      // Close across the top edge back to the start.
-      ..close();
+    // Clip to the screen shape, then fill with black. This black fill is
+    // visible in the cutout region because the child's ClipPath (applied by
+    // ScreenClipWidget) subtracts the cutout area, letting this fill show.
+    canvas.clipPath(screenPath);
+    canvas.drawRect(Offset.zero & size, Paint()..color = _kScreenColor);
   }
 
   @override
@@ -204,8 +72,224 @@ class ScreenClipPainter extends CustomPainter {
       oldDelegate.profile != profile || oldDelegate.orientation != orientation;
 }
 
-Radius _cornerRadius(ScreenBorder border) {
+// ── Screen shape path ─────────────────────────────────────────────────────────
+
+/// Builds the screen outline path for [border] at [size].
+Path _buildScreenPath(Size size, ScreenBorder border) {
   return switch (border) {
-    CircularBorder(:final radius) => Radius.circular(radius),
+    CircularBorder(:final radius) =>
+      Path()..addRRect(
+        RRect.fromRectAndRadius(Offset.zero & size, Radius.circular(radius)),
+      ),
+    SquircleBorder() => _buildSquirclePath(size, border),
   };
+}
+
+/// Builds a full squircle screen outline path from the corner Bézier data in
+/// [border].
+///
+/// [SquircleBorder.segments] describe the top-right corner going from the
+/// tangent on the top edge to the tangent on the right edge, in coordinates
+/// relative to the top-right corner position (logW, 0). The painter reflects
+/// and rotates this corner to trace all four corners and close the path.
+///
+/// Corner construction:
+///   - Top edge runs from top-left tangent (tTL) to top-right tangent (tTR).
+///   - Top-right squircle arc: segments as-is, starting at tTR.
+///   - Right edge runs from bottom of top-right arc to top of bottom-right arc.
+///   - Bottom-right squircle arc: top-right reflected vertically (y → h−y).
+///   - Bottom edge and remaining corners follow the same pattern.
+Path _buildSquirclePath(Size size, SquircleBorder border) {
+  final w = size.width;
+  final h = size.height;
+  final topT = border.topTangentLength;
+  final sideT = border.sideTangentLength;
+  final segs = border.segments;
+
+  final path = Path();
+
+  // ── Top edge ────────────────────────────────────────────────────────────
+  // Start at the top-left tangent point and draw across to the top-right.
+  path.moveTo(topT, 0); // top-left tangent (mirror of top-right)
+  path.lineTo(w - topT, 0); // top-right tangent
+
+  // ── Top-right corner ────────────────────────────────────────────────────
+  // Segments are relative to corner (w, 0): offset_x = seg_x + w, offset_y = seg_y.
+  _addCornerSegments(path, segs, ox: w, oy: 0, sx: 1, sy: 1);
+
+  // ── Right edge ──────────────────────────────────────────────────────────
+  path.lineTo(w, h - sideT);
+
+  // ── Bottom-right corner ─────────────────────────────────────────────────
+  // Reflect top-right vertically: x stays the same, y → h − y.
+  // Corner origin is (w, h); sy = −1 reflects y, then shift by oy = h.
+  _addCornerSegments(path, segs, ox: w, oy: h, sx: 1, sy: -1);
+
+  // ── Bottom edge ─────────────────────────────────────────────────────────
+  path.lineTo(topT, h);
+
+  // ── Bottom-left corner ───────────────────────────────────────────────────
+  // Reflect both axes from top-right. Corner origin is (0, h).
+  _addCornerSegments(path, segs, ox: 0, oy: h, sx: -1, sy: -1);
+
+  // ── Left edge ───────────────────────────────────────────────────────────
+  path.lineTo(0, sideT);
+
+  // ── Top-left corner ──────────────────────────────────────────────────────
+  // Reflect top-right horizontally. Corner origin is (0, 0).
+  _addCornerSegments(path, segs, ox: 0, oy: 0, sx: -1, sy: 1);
+
+  path.close();
+  return path;
+}
+
+/// Appends the squircle corner [segs] to [path], transforming each point by:
+///   x_out = ox + sx * seg_x
+///   y_out = oy + sy * seg_y
+///
+/// This lets us reuse the top-right corner segments for all four corners by
+/// changing the sign of sx / sy and the corner origin (ox, oy).
+void _addCornerSegments(
+  Path path,
+  List<double> segs, {
+  required double ox,
+  required double oy,
+  required double sx,
+  required double sy,
+}) {
+  for (var i = 0; i + 5 < segs.length; i += 6) {
+    path.cubicTo(
+      ox + sx * segs[i],
+      oy + sy * segs[i + 1],
+      ox + sx * segs[i + 2],
+      oy + sy * segs[i + 3],
+      ox + sx * segs[i + 4],
+      oy + sy * segs[i + 5],
+    );
+  }
+}
+
+// ── Cutout paths ──────────────────────────────────────────────────────────────
+
+Path _buildCutoutPath(ScreenCutout cutout, Rect screenRect) {
+  return switch (cutout) {
+    NoCutout() => Path(),
+    TeardropCutout(
+      :final width,
+      :final height,
+      :final bottomRadius,
+      :final sideRadius,
+    ) =>
+      _buildTeardropPath(
+        screenRect,
+        width: width,
+        height: height,
+        bottomRadius: bottomRadius,
+        sideRadius: sideRadius,
+      ),
+    NotchCutout(:final size, :final topOffset) =>
+      Path()..addRRect(
+        RRect.fromRectAndRadius(
+          Rect.fromLTWH(
+            screenRect.left + (screenRect.width - size.width) / 2,
+            screenRect.top + topOffset,
+            size.width,
+            size.height,
+          ),
+          const Radius.circular(4),
+        ),
+      ),
+    DynamicIslandCutout(:final size, :final topOffset) =>
+      Path()..addRRect(
+        RRect.fromRectAndRadius(
+          Rect.fromLTWH(
+            screenRect.left + (screenRect.width - size.width) / 2,
+            screenRect.top + topOffset,
+            size.width,
+            size.height,
+          ),
+          // Pill shape — fully rounded on the short axis.
+          Radius.circular(size.height / 2),
+        ),
+      ),
+    PunchHoleCutout(:final diameter, :final topOffset, :final centerX) =>
+      Path()..addOval(
+        Rect.fromCenter(
+          center: Offset(
+            centerX != null ? screenRect.left + centerX : screenRect.center.dx,
+            screenRect.top + topOffset,
+          ),
+          width: diameter,
+          height: diameter,
+        ),
+      ),
+    SideCutout(
+      :final size,
+      :final centerOffset,
+      :final edgeOffset,
+      :final cornerRadius,
+    ) =>
+      Path()..addRRect(
+        RRect.fromRectAndRadius(
+          Rect.fromLTWH(
+            screenRect.left + edgeOffset,
+            screenRect.top + centerOffset - size.height / 2,
+            size.width,
+            size.height,
+          ),
+          Radius.circular(cornerRadius),
+        ),
+      ),
+  };
+}
+
+// Builds the clip path for a TeardropCutout centred at the top of
+// [screenRect]. The shape is a narrow U with:
+//   - concave "ear" arcs (radius [sideRadius]) at the top corners, curving
+//     outward into the screen area
+//   - straight sides running down from the ears
+//   - a semicircular bottom arc (radius [bottomRadius]) surrounding the camera
+Path _buildTeardropPath(
+  Rect screenRect, {
+  required double width,
+  required double height,
+  required double bottomRadius,
+  required double sideRadius,
+}) {
+  final cx = screenRect.left + screenRect.width / 2;
+  final top = screenRect.top;
+  return Path()
+    // Left ear: concave arc from the outer top edge into the left wall.
+    ..moveTo(cx - width / 2 - sideRadius, top)
+    ..arcToPoint(
+      Offset(cx - width / 2, top + sideRadius),
+      radius: Radius.circular(sideRadius),
+      clockwise: true,
+    )
+    // Left straight side, down to where the bottom arc begins.
+    ..lineTo(cx - width / 2, top + height - bottomRadius)
+    // Bottom left corner.
+    ..arcToPoint(
+      Offset(cx - width / 2 + bottomRadius, top + height),
+      radius: Radius.circular(bottomRadius),
+      clockwise: false,
+    )
+    // Line across the bottom.
+    ..lineTo(cx + width / 2 - bottomRadius, top + height)
+    // Bottom right corner.
+    ..arcToPoint(
+      Offset(cx + width / 2, top + height - bottomRadius),
+      radius: Radius.circular(bottomRadius),
+      clockwise: false,
+    )
+    // Right straight side, back up to the ear.
+    ..lineTo(cx + width / 2, top + sideRadius)
+    // Right ear: symmetric concave arc back to the top edge.
+    ..arcToPoint(
+      Offset(cx + width / 2 + sideRadius, top),
+      radius: Radius.circular(sideRadius),
+      clockwise: true,
+    )
+    // Close across the top edge back to the start.
+    ..close();
 }

--- a/lib/src/ui/preview_overlay.dart
+++ b/lib/src/ui/preview_overlay.dart
@@ -146,5 +146,8 @@ class PreviewOverlay extends StatelessWidget {
 double _cornerRadiusValue(ScreenBorder border) {
   return switch (border) {
     CircularBorder(:final radius) => radius,
+    // Use topTangentLength as an approximation for the outer shadow radius on
+    // the RaisedSurface — close enough for the cosmetic drop shadow.
+    SquircleBorder(:final topTangentLength) => topTangentLength,
   };
 }


### PR DESCRIPTION
Step 5.4 of the iOS screen geometry fidelity phase (issue #63).

- `SquircleBorder` added to `ScreenBorder`: stores the Simulator-extracted cubic Bézier segments for one corner (top-right, relative coordinates, Flutter logical pts with y-down)
- Five iPhone profiles updated from `CircularBorder` to `SquircleBorder` with exact PDF-extracted control points:
  - `iphone_14` (390×844, tangent 67.46pt — iPhone 12/13/14 family)
  - `iphone_15` / `iphone_17` (393×852, tangent 74.65pt — iPhone 14 Pro/15/16/17 family)
  - `iphone_15_pro_max` (430×932, same tangent length as 393pt family)
  - `iphone_17_pro_max` (440×956, tangent 85.16pt)
- `ScreenClipPainter` updated: `_buildSquirclePath` reflects and rotates the one extracted corner to all four via sign-flip transforms; `paint()` and `buildClipPath()` now use `clipPath` instead of `clipRRect` for squircle profiles