### PR TITLE
plan Phase 6 UI refactor; minor README and doc polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Flight Check
 
-Flight Check is a Flutter tool for previewing your app across different mobile
-device profiles — so you know what it looks like without guesswork.
+Flight Check is a development time tool for Flutter that lets you preview your
+app across different mobile device profiles — so you'll know what it looks like
+without guesswork.
 
-`MediaQuery` and safe areas report what a real device would report, thanks to
-binding-layer emulation. And Flight Check is tree-shaken out in release mode, so
-you don't ship any unnecessary code.
+We support a broad range of device profiles covering common screen sizes, device
+types, and notch type and safe areas sizes.
 
-| iPhone 17 | Pixel 10 | Galaxy S24 |
-|:---------:|:--------:|:----------:|
-| ![iPhone 17](docs/images/iphone_17.png) | ![Pixel 10](docs/images/pixel_10.png) | ![Galaxy S24](docs/images/galaxy_s24.png) |
+We use binding-layer emulation, so `MediaQuery` and safe areas report what a
+real device would. And Flight Check is tree-shaken out in release mode, so you
+don't ship any unnecessary code.
 
 ## Getting started
 
@@ -31,19 +31,15 @@ void main() {
 }
 ```
 
-Run your app on macOS, Linux, or Windows and the preview UI appears
-automatically. The call is a no-op in several situations, so you can leave it
-in unconditionally:
+Then run your app as Flutter Desktop app on macOS, Linux, or Windows; the
+preview UI appears automatically. You can even leave the call in
+unconditionally; Flight Check is tree-shaken out at compile time for release
+builds.
 
 - **Release / profile builds** — tree-shaken out at compile time
-- **iOS / Android** — skipped at runtime so real-device debug sessions are
-  unaffected
+- **iOS / Android devices** — skipped at runtime so real-device debug sessions
+  are unaffected
 - **Flutter Web** — excluded via a conditional import
-
-## WidgetsFlutterBinding.ensureInitialized()
-
-If your app calls `WidgetsFlutterBinding.ensureInitialized()`, place the call to
-`FlightCheck.configure()` before the `WidgetsFlutterBinding` call.
 
 ## Supported devices
 
@@ -71,6 +67,17 @@ If your app calls `WidgetsFlutterBinding.ensureInitialized()`, place the call to
 | --- | --- | --- |
 | iPad mini (A17 Pro) | 744 × 1133 | Compact iPad, 744 × 1133 |
 | iPad (A16) | 820 × 1180 | Standard iPad, 820 × 1180 |
+
+### Screenshots
+
+| iPhone 17 | Pixel 10 | Galaxy S24 |
+|:---------:|:--------:|:----------:|
+| ![iPhone 17](docs/images/iphone_17.png) | ![Pixel 10](docs/images/pixel_10.png) | ![Galaxy S24](docs/images/galaxy_s24.png) |
+
+## Calling WidgetsFlutterBinding.ensureInitialized()?
+
+If your app calls `WidgetsFlutterBinding.ensureInitialized()`, place the call to
+`FlightCheck.configure()` before the `WidgetsFlutterBinding` call.
 
 ## Known limitations
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -294,11 +294,112 @@ Add a `PathCutout` variant to `ScreenCutout` that stores raw Bézier segments
 from the sensor bar PDF. Implement rendering in `ScreenClipPainter`. Replace
 the `TeardropCutout` on `iphone_14` with a `PathCutout`.
 
-## Phase 5 — General polish
+## Phase 6 — Refactor Flight Check UI
+
+Move all Flight Check controls out of the bottom chrome and into an overlay
+badge + panel anchored to the top-right corner. This eliminates the bottom
+toolbar entirely, making the emulator area edge-to-edge with the window content
+area. The primary motivation is to remove the bottom chrome from the window
+sizing and DPR calculations — a persistent source of subtle bugs where two
+independent formulas must stay in sync.
+
+### Step 6.1 — Remove macOS menu bar integration
+
+Delete `MacosPreviewMenu` and its file (`lib/src/ui/macos_menu.dart`). Remove
+the `MacosPreviewMenu` wrapper from `PreviewOverlay.build`. The native menu bar
+is not discoverable and will be replaced by in-app controls.
+
+### Step 6.2 — Control badge widget
+
+Create `lib/src/ui/control_badge.dart` — a small semi-transparent widget
+anchored to the top-right corner of the window.
+
+**Visual design:**
+- Extends down from the top edge and in from the right edge — an "inverted tab"
+  with one rounded corner (bottom-left). No other rounded corners.
+- Semi-transparent background (same hue as `kPreviewBackground`, ~70% opacity).
+- Displays the current device name (e.g. "iPhone 17") in a compact label.
+- Tap toggles the device picker panel open/closed.
+
+**Passthrough mode:** badge stays visible but dims slightly (lower opacity or
+smaller font) so users can return to preview mode without knowing a shortcut.
+
+Wire it into `PreviewOverlay` as a `Positioned` widget in the existing `Stack`.
+At this point both the old toolbar and the new badge are visible — that is
+intentional so the overlay remains fully functional during the transition.
+
+### Step 6.3 — Anchored picker panel and action bar
+
+Redesign the device picker to slide down from the top-right corner, physically
+connected to the control badge.
+
+**Panel contents (top to bottom):**
+1. **Action icon row** — orientation toggle, passthrough toggle, keyboard
+   shortcuts icon. Compact row of `IconButton`s with tooltips.
+2. **Keyboard shortcuts popover** — tapping the keyboard icon reveals a list of
+   active key bindings (inline expand or small overlay). Aids discoverability.
+3. **Tabbed device list** — reuse the existing iOS / Android / Tablets tab
+   structure and `_DeviceList` / `_DeviceItem` widgets.
+
+**Animation:** slides down from beneath the badge (origin at top-right), fading
+in. Reverse to dismiss. Tap-outside-to-dismiss backdrop stays.
+
+The panel shares the same semi-transparent background as the badge so they read
+as one connected surface.
+
+### Step 6.4 — Remove old toolbar and neumorphic surface; edge-to-edge layout
+
+- Delete `PreviewToolbar` (`lib/src/ui/preview_toolbar.dart`).
+- Delete `RaisedSurface` (`lib/src/ui/common.dart`) or hollow it out if other
+  code still references it.
+- In `PreviewOverlay`: remove the bottom `Column` children (`kPreviewSpacing`
+  spacer, `SizedBox(height: kToolbarHeight)`, `kPreviewPadding` spacer). The
+  `Expanded` child with the `LayoutBuilder` becomes the only column child —
+  the emulator area fills the full content area.
+- Drop the `RaisedSurface` wrapper around the emulated device `SizedBox`.
+- Keep `kPreviewBackground` as the window background (visible behind rounded
+  device corners and cutout regions).
+- Remove or zero-out `kPreviewSpacing`, `kToolbarHeight`, `kPreviewPadding`
+  from `theme.dart`. If any of these constants are still referenced elsewhere,
+  remove those references first.
+
+### Step 6.5 — Simplify window sizing and DPR calculation
+
+With no bottom chrome, both formulas collapse:
+
+**`WindowManagerSizingService.applyProfile`:**
+- Window height = `target.height + titleBarHeight` (no `bottomControlsHeight`).
+- Clamping: if window exceeds screen, scale down proportionally; window height
+  = `clampedDeviceHeight + titleBarHeight`.
+- Remove all references to `bottomControlsHeight`.
+
+**`PreviewFlutterView.devicePixelRatio`:**
+- `DPR = min(physicalWidth / emulatedWidth, physicalHeight / emulatedHeight)`.
+- No chrome subtraction — the real physical size *is* the emulator area.
+
+Update `computeTargetSize` and its tests. The two formulas are now trivially
+consistent because there is no shared constant that must match.
+
+### Step 6.6 — Keyboard shortcuts
+
+Re-populate `PreviewShortcuts` with:
+
+| Shortcut | Action |
+|---|---|
+| `Cmd+D` / `Ctrl+D` | Toggle device picker |
+| `Cmd+L` / `Ctrl+L` | Toggle orientation |
+| `Cmd+]` / `Ctrl+]` | Next device |
+| `Cmd+[` / `Ctrl+[` | Previous device |
+
+Add `cycleDevice(int delta)` to `PreviewController` — advances through
+`DeviceDatabase.all` by `delta` (+1 or −1), wrapping around.
+
+Surface the shortcut list in the keyboard shortcuts popover from step 6.3.
+
+## Phase 7 — General polish
 
 + Add iPhone 17 Pro device profile (402 × 874) (devoncarew/flight_check#59)
 + Add iPhone 17 Air device profile (420 × 912) (devoncarew/flight_check#60)
 - Add Samsung Galaxy S25 device profile (devoncarew/flight_check#62)
 - Add Samsung Galaxy A55 device profile (devoncarew/flight_check#61)
 - Consider a locale override.
-- Fix the tall device window sizing bug.

--- a/lib/flight_check.dart
+++ b/lib/flight_check.dart
@@ -1,11 +1,13 @@
 /// Flight Check — Flutter debug-mode device preview tool.
 ///
 /// Add two lines to your `main.dart`:
+///
 /// ```dart
 /// import 'package:flight_check/flight_check.dart';
 ///
 /// void main() {
 ///   FlightCheck.configure();
+///
 ///   runApp(const MyApp());
 /// }
 /// ```


### PR DESCRIPTION
Plans the Phase 6 UI refactor in PLAN.md and includes minor README and dartdoc polish from earlier in this session.

- **Phase 6 plan** (6 steps): move Flight Check controls into an anchored badge + panel in the top-right corner, drop the bottom toolbar chrome, and simplify window sizing / DPR math — removing the coupling between two formulas that must stay in sync
- **README**: reworded intro, moved screenshot table under Supported Devices, gave the `WidgetsFlutterBinding` note a proper heading
- **flight_check.dart**: minor blank-line formatting in the dartdoc code snippet