### PR TITLE
Badge and panel: phone icon, border, drop shadow

### DIFF
--- a/lib/src/theme.dart
+++ b/lib/src/theme.dart
@@ -14,4 +14,4 @@ const Color kPreviewForegroundEmphasis = Color(0xFFFFFFFF);
 ///
 /// Used to position the [ControlPanel] immediately below the badge so they
 /// read as one connected surface.
-const double kControlBadgeHeight = 24 + 4;
+const double kControlBadgeHeight = 29 + 4;

--- a/lib/src/ui/control_badge.dart
+++ b/lib/src/ui/control_badge.dart
@@ -75,54 +75,71 @@ class _ControlBadgeState extends State<ControlBadge>
           cursor: SystemMouseCursors.click,
           child: GestureDetector(
             onTap: widget.controller.toggleDevicePicker,
-            child: ClipRRect(
-              borderRadius: const BorderRadius.only(
-                bottomLeft: Radius.circular(10),
-              ),
-              child: AnimatedBuilder(
-                animation: _anim,
-                builder: (context, _) => ColoredBox(
+            child: AnimatedBuilder(
+              animation: _anim,
+              builder: (context, _) => Container(
+                clipBehavior: Clip.antiAlias,
+                decoration: BoxDecoration(
                   color: kPreviewBackground.withValues(
                     alpha: dimmed ? 0.4 : _bgAlpha.value,
                   ),
-                  child: Padding(
-                    padding: const EdgeInsets.only(
-                      left: 8,
-                      right: 6,
-                      top: 4,
-                      bottom: 6,
-                    ),
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Text(
-                          widget.controller.activeProfile.name,
-                          style: TextStyle(
-                            color: kPreviewForeground.withValues(
-                              alpha: foregroundAlpha,
-                            ),
-                            fontSize: 12,
-                            fontWeight: FontWeight.w500,
-                            decoration: TextDecoration.none,
-                          ),
-                        ),
-                        const SizedBox(width: 4),
-                        RotationTransition(
-                          turns: Tween<double>(
-                            begin: 0.0,
-                            end: 0.5,
-                          ).animate(_chevron),
-                          child: Icon(
-                            Icons.expand_more,
-                            size: 14,
-                            color: kPreviewForeground.withValues(
-                              alpha: foregroundAlpha,
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
+                  borderRadius: const BorderRadius.only(
+                    bottomLeft: Radius.circular(10),
                   ),
+                  border: Border.all(
+                    color: kPreviewForeground.withValues(alpha: 0.15),
+                  ),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black.withValues(alpha: 0.35),
+                      blurRadius: 8,
+                      offset: const Offset(-2, 3),
+                    ),
+                  ],
+                ),
+                padding: const EdgeInsets.only(
+                  left: 8,
+                  right: 6,
+                  top: 5,
+                  bottom: 7,
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      Icons.phone_android,
+                      size: 13,
+                      color: kPreviewForeground.withValues(
+                        alpha: foregroundAlpha,
+                      ),
+                    ),
+                    const SizedBox(width: 5),
+                    Text(
+                      widget.controller.activeProfile.name,
+                      style: TextStyle(
+                        color: kPreviewForeground.withValues(
+                          alpha: foregroundAlpha,
+                        ),
+                        fontSize: 12,
+                        fontWeight: FontWeight.w500,
+                        decoration: TextDecoration.none,
+                      ),
+                    ),
+                    const SizedBox(width: 4),
+                    RotationTransition(
+                      turns: Tween<double>(
+                        begin: 0.0,
+                        end: 0.5,
+                      ).animate(_chevron),
+                      child: Icon(
+                        Icons.expand_more,
+                        size: 14,
+                        color: kPreviewForeground.withValues(
+                          alpha: foregroundAlpha,
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
               ),
             ),

--- a/lib/src/ui/control_panel.dart
+++ b/lib/src/ui/control_panel.dart
@@ -115,20 +115,20 @@ class _ControlPanelState extends State<ControlPanel>
           ),
 
           // Panel card anchored below the badge, slides in from the right.
-          // ClipRect prevents the card from being visible while off-screen.
+          // No ClipRect needed — the Stack fills the window so the panel is
+          // naturally clipped at the window edge during the slide animation,
+          // and removing ClipRect allows the drop shadow to render correctly.
           Positioned(
             top: kControlBadgeHeight,
             right: 0,
-            child: ClipRect(
-              child: SlideTransition(
-                position: Tween<Offset>(
-                  begin: const Offset(1, 0),
-                  end: Offset.zero,
-                ).animate(_slideAnim),
-                child: SizedBox(
-                  height: math.min(maxHeight, _kPanelHeight),
-                  child: _buildContents(context),
-                ),
+            child: SlideTransition(
+              position: Tween<Offset>(
+                begin: const Offset(1, 0),
+                end: Offset.zero,
+              ).animate(_slideAnim),
+              child: SizedBox(
+                height: math.min(maxHeight, _kPanelHeight),
+                child: _buildContents(context),
               ),
             ),
           ),
@@ -156,79 +156,109 @@ class _ControlPanelState extends State<ControlPanel>
           DefaultMaterialLocalizations.delegate,
           DefaultWidgetsLocalizations.delegate,
         ],
-        child: Material(
-          color: kPreviewBackground,
-          borderRadius: _kPanelBorderRadius,
-          clipBehavior: Clip.antiAlias,
-          child: Column(
-            children: [
-              _ActionRow(controller: widget.controller),
-              const Divider(height: 1, thickness: 1, color: Color(0x33FFFFFF)),
-              const SizedBox(height: 8),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                child: _createSegmentedButton(),
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            borderRadius: _kPanelBorderRadius,
+            border: Border.all(
+              color: kPreviewForeground.withValues(alpha: 0.15),
+            ),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withValues(alpha: 0.35),
+                blurRadius: 8,
+                offset: const Offset(-2, 3),
               ),
-              const SizedBox(height: 4),
-              const Divider(height: 1, thickness: 1, color: Color(0x33FFFFFF)),
-              Expanded(
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 8,
-                    vertical: 4,
+            ],
+          ),
+          child: Material(
+            color: kPreviewBackground,
+            borderRadius: _kPanelBorderRadius,
+            clipBehavior: Clip.antiAlias,
+            child: Column(
+              children: [
+                _ActionRow(controller: widget.controller),
+                const Divider(
+                  height: 1,
+                  thickness: 1,
+                  color: Color(0x33FFFFFF),
+                ),
+                const SizedBox(height: 8),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: _createSegmentedButton(),
+                ),
+                const SizedBox(height: 4),
+                const Divider(
+                  height: 1,
+                  thickness: 1,
+                  color: Color(0x33FFFFFF),
+                ),
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 8,
+                      vertical: 4,
+                    ),
+                    child: IndexedStack(
+                      index: _selectedTab,
+                      alignment: AlignmentDirectional.topStart,
+                      children: [
+                        _DeviceList(
+                          profiles: iOS,
+                          controller: widget.controller,
+                        ),
+                        _DeviceList(
+                          profiles: android,
+                          controller: widget.controller,
+                        ),
+                        _DeviceList(
+                          profiles: tablets,
+                          controller: widget.controller,
+                        ),
+                      ],
+                    ),
                   ),
-                  child: IndexedStack(
-                    index: _selectedTab,
-                    alignment: AlignmentDirectional.topStart,
+                ),
+                const Divider(
+                  height: 1,
+                  thickness: 1,
+                  color: Color(0x33FFFFFF),
+                ),
+                // Footer area.
+                Padding(
+                  padding: const EdgeInsets.only(
+                    top: 8,
+                    bottom: 12,
+                    left: 8,
+                    right: 8,
+                  ),
+                  child: Row(
                     children: [
-                      _DeviceList(profiles: iOS, controller: widget.controller),
-                      _DeviceList(
-                        profiles: android,
-                        controller: widget.controller,
+                      _ShortcutButton(
+                        icon: Icons.devices,
+                        binding: '${Platform.isMacOS ? '⌘' : '^'}D',
+                        tooltip: 'Toggle device picker',
+                        onTap: widget.controller.toggleDevicePicker,
                       ),
-                      _DeviceList(
-                        profiles: tablets,
-                        controller: widget.controller,
+                      const Expanded(child: SizedBox(width: 16)),
+                      _ShortcutButton(
+                        icon: Icons.skip_previous,
+                        binding: '${Platform.isMacOS ? '⌘' : '^'}[',
+                        tooltip: 'Previous device',
+                        onTap: () => widget.controller.cycleDevice(-1),
+                      ),
+                      const SizedBox(width: 8),
+                      _ShortcutButton(
+                        icon: Icons.skip_next,
+                        binding: '${Platform.isMacOS ? '⌘' : '^'}]',
+                        tooltip: 'Next device',
+                        onTap: () => widget.controller.cycleDevice(1),
                       ),
                     ],
                   ),
                 ),
-              ),
-              const Divider(height: 1, thickness: 1, color: Color(0x33FFFFFF)),
-              // Footer area.
-              Padding(
-                padding: const EdgeInsets.only(
-                  top: 8,
-                  bottom: 12,
-                  left: 8,
-                  right: 8,
-                ),
-                child: Row(
-                  children: [
-                    _ShortcutButton(
-                      icon: Icons.devices,
-                      binding: '${Platform.isMacOS ? '⌘' : '^'}D',
-                      tooltip: 'Toggle device picker',
-                      onTap: widget.controller.toggleDevicePicker,
-                    ),
-                    const Expanded(child: SizedBox(width: 16)),
-                    _ShortcutButton(
-                      icon: Icons.skip_previous,
-                      binding: '${Platform.isMacOS ? '⌘' : '^'}[',
-                      tooltip: 'Previous device',
-                      onTap: () => widget.controller.cycleDevice(-1),
-                    ),
-                    const SizedBox(width: 8),
-                    _ShortcutButton(
-                      icon: Icons.skip_next,
-                      binding: '${Platform.isMacOS ? '⌘' : '^'}]',
-                      tooltip: 'Next device',
-                      onTap: () => widget.controller.cycleDevice(1),
-                    ),
-                  ],
-                ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
Visual polish for the control badge and panel.

- **ControlBadge**: add smartphone icon prefix, subtle border (15% white), and drop shadow; switch internals from `ClipRRect`/`ColoredBox` to `Container` with `BoxDecoration`
- **ControlPanel**: add matching border and drop shadow via `DecoratedBox` wrapper; remove `ClipRect` from the slide animation so the shadow is not clipped by it

🤖 Generated with [Claude Code](https://claude.com/claude-code)