### PR TITLE
Add dark/light mode toggle to preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 * Added `shortName` field to `DeviceProfile` for compact display in the control
   badge (e.g. `'Pixel 10'` instead of `'Google Pixel 10'`). The badge shows the
   short name when the panel is closed, and the full name when it is open.
+* Added brightness (dark/light) toggle to the control panel (`⌘B` / `Ctrl+B`).
+  The emulated device always reports an explicit brightness — dark by default —
+  independent of the host system setting. The choice persists between sessions.
 
 ## 1.0.0
 

--- a/README.md
+++ b/README.md
@@ -46,27 +46,27 @@ tree-shaken out at compile time.
 
 | Device | Size | Device category |
 | --- | --- | --- |
-| iPhone SE (3rd gen) | 375x667 | Flat-edge, no cutout, small screen — budget / upgrade path |
-| iPhone 14 | 390x844 | Notch, 390×844 — covers iPhone 12, 13, 14 |
-| iPhone 15 | 393x852 | Dynamic Island, 393×852 — proxy for iPhone 14 Pro, 15 Pro, 16, 16e |
-| iPhone 15 Pro Max | 430x932 | Dynamic Island, 430×932 — covers iPhone 15 Plus, 16 Plus |
-| iPhone 17 | 402x874 | Current standard iPhone, 402×874 — same geometry as iPhone 17 Pro |
-| iPhone 17 Air | 420x912 | Dynamic Island, 420×912 — iPhone 17 Air |
-| iPhone 17 Pro | 402x874 | Dynamic Island, 402×874 — covers iPhone 16 Pro, 17 Pro |
-| iPhone 17 Pro Max | 440x956 | Largest iPhone screen, 440×956 |
+| iPhone&nbsp;SE&nbsp;(3rd&nbsp;gen) | 375x667 | Flat-edge, no cutout, small screen — budget / upgrade path |
+| iPhone&nbsp;14 | 390x844 | Notch, 390×844 — covers iPhone 12, 13, 14 |
+| iPhone&nbsp;15 | 393x852 | Dynamic Island, 393×852 — proxy for iPhone 14 Pro, 15 Pro, 16, 16e |
+| iPhone&nbsp;15&nbsp;Pro&nbsp;Max | 430x932 | Dynamic Island, 430×932 — covers iPhone 15 Plus, 16 Plus |
+| iPhone&nbsp;17 | 402x874 | Current standard iPhone, 402×874 — same geometry as iPhone 17 Pro |
+| iPhone&nbsp;17&nbsp;Air | 420x912 | Dynamic Island, 420×912 — iPhone 17 Air |
+| iPhone&nbsp;17&nbsp;Pro | 402x874 | Dynamic Island, 402×874 — covers iPhone 16 Pro, 17 Pro |
+| iPhone&nbsp;17&nbsp;Pro&nbsp;Max | 440x956 | Largest iPhone screen, 440×956 |
 | &nbsp; | | |
-| Google Pixel 7a | 411x914 | Mid-range Pixel, small punch hole — covers Pixel 7a, 8, 8a |
-| Google Pixel 10 | 411x923 | Large punch hole, 411×923 — covers Pixel 9 and 10 |
-| Google Pixel 10 Pro | 410x914 | High-DPR Pixel (3.125), 410×914 |
-| Samsung Galaxy A15 | 411x892 | Budget Samsung Infinity-U notch, 411×892 — covers A15, A25 |
-| Samsung Galaxy A16 | 411x892 | Budget Samsung Infinity-U notch, 411×892 — covers A06, A16, M16 |
-| Samsung Galaxy A55 | 384x854 | Mid-range Samsung A-series, 384×854 — covers A54, A55 |
-| Samsung Galaxy A56 | 412x915 | Mid-range Samsung A-series, 412×915 — covers A36, A56 |
-| Samsung Galaxy S25 | 360x780 | Flagship Samsung S25, 360×780 — slightly rounder corners than S24/S26 |
-| Samsung Galaxy S26 | 360x780 | Flagship Samsung, 360×780 — covers S24, S26 |
+| Google&nbsp;Pixel&nbsp;7a | 411x914 | Mid-range Pixel, small punch hole — covers Pixel 7a, 8, 8a |
+| Google&nbsp;Pixel&nbsp;10 | 411x923 | Large punch hole, 411×923 — covers Pixel 9 and 10 |
+| Google&nbsp;Pixel&nbsp;10&nbsp;Pro | 410x914 | High-DPR Pixel (3.125), 410×914 |
+| Samsung&nbsp;Galaxy&nbsp;A15 | 411x892 | Budget Samsung Infinity-U notch, 411×892 — covers A15, A25 |
+| Samsung&nbsp;Galaxy&nbsp;A16 | 411x892 | Budget Samsung Infinity-U notch, 411×892 — covers A06, A16, M16 |
+| Samsung&nbsp;Galaxy&nbsp;A55 | 384x854 | Mid-range Samsung A-series, 384×854 — covers A54, A55 |
+| Samsung&nbsp;Galaxy&nbsp;A56 | 412x915 | Mid-range Samsung A-series, 412×915 — covers A36, A56 |
+| Samsung&nbsp;Galaxy&nbsp;S25 | 360x780 | Flagship Samsung S25, 360×780 — slightly rounder corners than S24/S26 |
+| Samsung&nbsp;Galaxy&nbsp;S26 | 360x780 | Flagship Samsung, 360×780 — covers S24, S26 |
 | &nbsp; | | |
-| iPad mini (A17 Pro) | 744x1133 | Compact iPad, 744×1133 |
-| iPad (A16) | 820x1180 | Standard iPad, 820×1180 |
+| iPad&nbsp;mini&nbsp;(A17&nbsp;Pro) | 744x1133 | Compact iPad, 744×1133 |
+| iPad&nbsp;(A16) | 820x1180 | Standard iPad, 820×1180 |
 
 ### Screenshots
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -27,37 +27,21 @@ class FlightCheckExampleApp extends StatefulWidget {
 }
 
 class _FlightCheckExampleAppState extends State<FlightCheckExampleApp> {
-  ThemeMode _themeMode = ThemeMode.light;
-
-  void _toggleTheme() {
-    setState(() {
-      _themeMode = _themeMode == ThemeMode.light
-          ? ThemeMode.dark
-          : ThemeMode.light;
-    });
-  }
-
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Stellar',
-      themeMode: _themeMode,
       theme: ThemeData.light(),
       darkTheme: ThemeData.dark(),
+      themeMode: ThemeMode.system,
       debugShowCheckedModeBanner: false,
-      home: _HomePage(
-        isDark: _themeMode == ThemeMode.dark,
-        onToggleTheme: _toggleTheme,
-      ),
+      home: const _HomePage(),
     );
   }
 }
 
 class _HomePage extends StatefulWidget {
-  const _HomePage({required this.isDark, required this.onToggleTheme});
-
-  final bool isDark;
-  final VoidCallback onToggleTheme;
+  const _HomePage();
 
   @override
   State<_HomePage> createState() => _HomePageState();
@@ -73,10 +57,6 @@ class _HomePageState extends State<_HomePage> {
         title: const Text('Stellar'),
         centerTitle: true,
         actions: [
-          IconButton(
-            icon: Icon(widget.isDark ? Icons.light_mode : Icons.dark_mode),
-            onPressed: widget.onToggleTheme,
-          ),
           IconButton(icon: Icon(Icons.adaptive.more), onPressed: () {}),
         ],
         actionsPadding: const EdgeInsets.symmetric(horizontal: 8),

--- a/lib/src/binding/preview_binding.dart
+++ b/lib/src/binding/preview_binding.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show Brightness;
+
 import 'package:flutter/foundation.dart'
     show TargetPlatform, debugDefaultTargetPlatformOverride;
 import 'package:flutter/widgets.dart' show Widget, WidgetsFlutterBinding;
@@ -61,7 +63,7 @@ class PreviewBinding extends WidgetsFlutterBinding {
       windowManager.ensureInitialized(),
     );
 
-    // Restore the last-selected device and orientation, if any.
+    // Restore the last-selected device, orientation, and brightness, if any.
     final savedId = loadLastDeviceId();
     if (savedId != null) {
       final profile = DeviceDatabase.findById(savedId);
@@ -71,6 +73,10 @@ class PreviewBinding extends WidgetsFlutterBinding {
     if (savedOrientation != null &&
         savedOrientation != _controller.orientation) {
       _controller.toggleOrientation();
+    }
+    final savedBrightness = loadLastBrightness();
+    if (savedBrightness != null) {
+      _controller.setBrightnessOverride(savedBrightness);
     }
 
     // Apply the platform override now, before runApp, so that ThemeData is
@@ -85,15 +91,30 @@ class PreviewBinding extends WidgetsFlutterBinding {
   String? _lastSavedProfileId;
   DeviceOrientation? _lastSavedOrientation;
   DevicePlatform? _lastEmulatedPlatform;
+  Brightness _lastBrightnessOverride = Brightness.dark;
 
   void _onControllerChanged() {
-    // Persist device ID and orientation when either changes.
+    // Persist device ID, orientation, and brightness when any changes.
     final id = _controller.activeProfile.id;
     final orientation = _controller.orientation;
-    if (id != _lastSavedProfileId || orientation != _lastSavedOrientation) {
+    final brightness = _controller.brightnessOverride;
+    if (id != _lastSavedProfileId ||
+        orientation != _lastSavedOrientation ||
+        brightness != _lastBrightnessOverride) {
       _lastSavedProfileId = id;
       _lastSavedOrientation = orientation;
-      saveSettings(deviceId: id, orientation: orientation);
+      saveSettings(
+        deviceId: id,
+        orientation: orientation,
+        brightness: brightness,
+      );
+    }
+
+    // Notify the framework when the brightness override changes so it re-reads
+    // platformBrightness and rebuilds theme-sensitive widgets.
+    if (brightness != _lastBrightnessOverride) {
+      _lastBrightnessOverride = brightness;
+      _previewDispatcher.notifyBrightnessChanged();
     }
 
     // Update the platform override when the emulated platform changes (e.g.

--- a/lib/src/binding/preview_flutter_view.dart
+++ b/lib/src/binding/preview_flutter_view.dart
@@ -12,10 +12,11 @@ import '../preview_controller.dart';
 /// propagates correct [MediaQueryData] to the widget tree without any widget
 /// injection.
 class PreviewFlutterView implements ui.FlutterView {
-  PreviewFlutterView(this._real, this._controller);
+  PreviewFlutterView(this._real, this._controller, this._dispatcher);
 
   final ui.FlutterView _real;
   final PreviewController _controller;
+  final ui.PlatformDispatcher _dispatcher;
 
   // ── Spoofed members ───────────────────────────────────────────────────────
 
@@ -68,7 +69,7 @@ class PreviewFlutterView implements ui.FlutterView {
   // ── Delegated members ─────────────────────────────────────────────────────
 
   @override
-  ui.PlatformDispatcher get platformDispatcher => _real.platformDispatcher;
+  ui.PlatformDispatcher get platformDispatcher => _dispatcher;
 
   @override
   ui.ViewConstraints get physicalConstraints => _real.physicalConstraints;

--- a/lib/src/binding/preview_platform_dispatcher.dart
+++ b/lib/src/binding/preview_platform_dispatcher.dart
@@ -20,6 +20,7 @@ class PreviewPlatformDispatcher implements ui.PlatformDispatcher {
   late final PreviewFlutterView _previewView = PreviewFlutterView(
     _real.views.first,
     _controller,
+    this,
   );
 
   // ── Spoofed members ───────────────────────────────────────────────────────
@@ -105,12 +106,25 @@ class PreviewPlatformDispatcher implements ui.PlatformDispatcher {
   set onTextScaleFactorChanged(ui.VoidCallback? value) =>
       _real.onTextScaleFactorChanged = value;
 
+  ui.VoidCallback? _onPlatformBrightnessChanged;
+
   @override
   ui.VoidCallback? get onPlatformBrightnessChanged =>
       _real.onPlatformBrightnessChanged;
+
+  /// Wraps the framework's [onPlatformBrightnessChanged] callback so we can
+  /// fire it ourselves when [PreviewController.brightnessOverride] changes.
   @override
-  set onPlatformBrightnessChanged(ui.VoidCallback? value) =>
-      _real.onPlatformBrightnessChanged = value;
+  set onPlatformBrightnessChanged(ui.VoidCallback? value) {
+    _onPlatformBrightnessChanged = value;
+    _real.onPlatformBrightnessChanged = value;
+  }
+
+  /// Fires the framework's [onPlatformBrightnessChanged] callback.
+  ///
+  /// Called by [PreviewBinding] when the brightness override changes, so that
+  /// the framework re-reads [platformBrightness] and rebuilds.
+  void notifyBrightnessChanged() => _onPlatformBrightnessChanged?.call();
 
   @override
   ui.VoidCallback? get onSystemFontFamilyChanged =>
@@ -211,7 +225,7 @@ class PreviewPlatformDispatcher implements ui.PlatformDispatcher {
   bool get brieflyShowPassword => _real.brieflyShowPassword;
 
   @override
-  ui.Brightness get platformBrightness => _real.platformBrightness;
+  ui.Brightness get platformBrightness => _controller.brightnessOverride;
 
   @override
   String? get systemFontFamily => _real.systemFontFamily;

--- a/lib/src/persistence/device_persistence.dart
+++ b/lib/src/persistence/device_persistence.dart
@@ -1,10 +1,13 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'dart:ui' show Brightness;
+
 import '../devices/device_profile.dart';
 
 const _kDeviceKey = 'lastDevice';
 const _kOrientationKey = 'lastOrientation';
+const _kBrightnessKey = 'lastBrightness';
 
 /// Returns the settings file path.
 ///
@@ -76,6 +79,24 @@ DeviceOrientation? loadLastOrientation() {
   }
 }
 
+/// Reads the last-used brightness from the settings file.
+///
+/// Returns `null` if absent or unreadable.
+Brightness? loadLastBrightness() {
+  try {
+    final file = _settingsFile();
+    if (file == null) return null;
+    final value = _readJson(file)[_kBrightnessKey] as String?;
+    return switch (value) {
+      'dark' => Brightness.dark,
+      'light' => Brightness.light,
+      _ => null,
+    };
+  } catch (_) {
+    return null;
+  }
+}
+
 /// Persists [id] and [orientation] to the settings file.
 ///
 /// Reads the existing file before writing so that any other fields in the
@@ -84,6 +105,7 @@ DeviceOrientation? loadLastOrientation() {
 void saveSettings({
   required String deviceId,
   required DeviceOrientation orientation,
+  required Brightness brightness,
 }) {
   try {
     final file = _settingsFile();
@@ -92,6 +114,9 @@ void saveSettings({
     final settings = _readJson(file);
     settings[_kDeviceKey] = deviceId;
     settings[_kOrientationKey] = orientation.name;
+    settings[_kBrightnessKey] = brightness == Brightness.dark
+        ? 'dark'
+        : 'light';
 
     // The $HOME/.config directory might not exist in some situations (on MacOS,
     // flutter run -d macos is sandboxed into an app specific directory).

--- a/lib/src/preview_controller.dart
+++ b/lib/src/preview_controller.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show Brightness;
+
 import 'package:flutter/foundation.dart' show ChangeNotifier;
 import 'package:flutter/painting.dart' show EdgeInsets, Size;
 
@@ -31,6 +33,7 @@ class PreviewController extends ChangeNotifier {
 
   bool _passthroughMode = false;
   bool _devicePickerVisible = false;
+  Brightness _brightnessOverride = Brightness.dark;
 
   /// The currently active device profile.
   DeviceProfile get activeProfile => _activeProfile;
@@ -46,6 +49,9 @@ class PreviewController extends ChangeNotifier {
 
   /// Whether the device picker is currently open.
   bool get devicePickerVisible => _devicePickerVisible;
+
+  /// The brightness the emulated device reports.
+  Brightness get brightnessOverride => _brightnessOverride;
 
   /// The emulated logical screen size for the current profile and orientation.
   Size get emulatedLogicalSize =>
@@ -83,6 +89,21 @@ class PreviewController extends ChangeNotifier {
   void togglePassthrough() {
     _passthroughMode = !_passthroughMode;
     notifyListeners();
+  }
+
+  /// Sets the emulated brightness and notifies listeners.
+  void setBrightnessOverride(Brightness brightness) {
+    if (_brightnessOverride == brightness) return;
+    _brightnessOverride = brightness;
+    notifyListeners();
+  }
+
+  /// Toggles the emulated brightness between dark and light.
+  void toggleBrightnessOverride() {
+    setBrightnessOverride(switch (_brightnessOverride) {
+      Brightness.dark => Brightness.light,
+      Brightness.light => Brightness.dark,
+    });
   }
 
   /// Toggles the device picker visibility and notifies listeners.

--- a/lib/src/ui/control_panel.dart
+++ b/lib/src/ui/control_panel.dart
@@ -325,6 +325,21 @@ class _ActionRow extends StatelessWidget {
               style: TextStyle(color: kPreviewForegroundEmphasis),
             ),
           ),
+          ListenableBuilder(
+            listenable: controller,
+            builder: (context, _) {
+              final icon = controller.brightnessOverride == Brightness.dark
+                  ? Icons.dark_mode
+                  : Icons.light_mode;
+              return _ShortcutButton(
+                icon: icon,
+                binding: '${_modifier}B',
+                tooltip: 'Toggle theme',
+                onTap: controller.toggleBrightnessOverride,
+              );
+            },
+          ),
+          const SizedBox(width: 8),
           _ShortcutButton(
             icon: Icons.screen_rotation,
             binding: '${_modifier}L',

--- a/lib/src/ui/preview_shortcuts.dart
+++ b/lib/src/ui/preview_shortcuts.dart
@@ -17,6 +17,11 @@ class ToggleOrientationIntent extends Intent {
   const ToggleOrientationIntent();
 }
 
+/// Fired by `Cmd+B` / `Ctrl+B` — cycles the brightness override.
+class ToggleBrightnessIntent extends Intent {
+  const ToggleBrightnessIntent();
+}
+
 /// Fired by `Cmd+]` / `Ctrl+]` — advances to the next device.
 class NextDeviceIntent extends Intent {
   const NextDeviceIntent();
@@ -60,6 +65,11 @@ class PreviewShortcuts extends StatelessWidget {
           control: !useMeta,
         ): const ToggleOrientationIntent(),
         SingleActivator(
+          LogicalKeyboardKey.keyB,
+          meta: useMeta,
+          control: !useMeta,
+        ): const ToggleBrightnessIntent(),
+        SingleActivator(
           LogicalKeyboardKey.bracketRight,
           meta: useMeta,
           control: !useMeta,
@@ -77,6 +87,9 @@ class PreviewShortcuts extends StatelessWidget {
           ),
           ToggleOrientationIntent: CallbackAction<ToggleOrientationIntent>(
             onInvoke: (_) => controller.toggleOrientation(),
+          ),
+          ToggleBrightnessIntent: CallbackAction<ToggleBrightnessIntent>(
+            onInvoke: (_) => controller.toggleBrightnessOverride(),
           ),
           NextDeviceIntent: CallbackAction<NextDeviceIntent>(
             onInvoke: (_) => controller.cycleDevice(1),

--- a/test/binding/preview_flutter_view_test.dart
+++ b/test/binding/preview_flutter_view_test.dart
@@ -15,6 +15,7 @@ void main() {
     view = PreviewFlutterView(
       binding.platformDispatcher.implicitView!,
       controller,
+      binding.platformDispatcher,
     );
   });
 

--- a/test/devices/device_database_test.dart
+++ b/test/devices/device_database_test.dart
@@ -55,9 +55,8 @@ void main() {
         first = false;
 
         for (final device in devices) {
-          print(
-            '| ${device.name} | ${size(device)} | ${device.description ?? ''} |',
-          );
+          final name = device.name.replaceAll(' ', '&nbsp;');
+          print('| $name | ${size(device)} | ${device.description ?? ''} |');
         }
       }
 


### PR DESCRIPTION
Adds a brightness toggle to the control panel so the emulated device always reports an explicit theme mode, independent of the host system setting.

- `PreviewController` owns a non-nullable `brightnessOverride` (defaults to dark); `PreviewFlutterView` now routes `platformDispatcher` through `PreviewPlatformDispatcher` so `MediaQueryData.fromView` sees the spoofed `platformBrightness`
- Control panel action row gains a dark/light icon button (`⌘B` / `Ctrl+B`) that toggles between modes; choice persists to `flight_check.json`
- Example app switched to `ThemeMode.system` to respond to the spoofed brightness