### PR TITLE
upgrade to flutter 3.44.0; fix issues and prep for publishing

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,12 @@
+{
+  "proseWrap": "always",
+  "printWidth": 80,
+  "overrides": [
+    {
+      "files": "*.yaml",
+      "options": {
+        "singleQuote": true
+      }
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,17 @@
+## 1.2.0
+
+- Require Flutter 3.44.0.
+- Implement `FlutterView.displayCornerRadii` to spoof Android corner radii.
+  Returns physical-pixel radii derived from the active profile's
+  `CircularBorder` radius; returns `null` for iOS profiles, matching Android API
+  31+ semantics.
+
 ## 1.1.0
 
-* Added `shortName` field to `DeviceProfile` for compact display in the control
+- Added `shortName` field to `DeviceProfile` for compact display in the control
   badge (e.g. `'Pixel 10'` instead of `'Google Pixel 10'`). The badge shows the
   short name when the panel is closed, and the full name when it is open.
-* Added brightness (dark/light) toggle to the control panel (`⌘B` / `Ctrl+B`).
+- Added brightness (dark/light) toggle to the control panel (`⌘B` / `Ctrl+B`).
   The emulated device always reports an explicit brightness — dark by default —
   independent of the host system setting. The choice persists between sessions.
 

--- a/lib/src/binding/preview_flutter_view.dart
+++ b/lib/src/binding/preview_flutter_view.dart
@@ -2,6 +2,8 @@ import 'dart:ui' as ui;
 
 import 'package:flutter/painting.dart' show EdgeInsets;
 
+import '../devices/device_profile.dart' show DevicePlatform;
+import '../devices/screen_border.dart' show CircularBorder;
 import '../preview_controller.dart';
 
 /// A [ui.FlutterView] that reports spoofed metrics for the active device
@@ -96,6 +98,28 @@ class PreviewFlutterView implements ui.FlutterView {
   @override
   void updateSemantics(ui.SemanticsUpdate update) =>
       _real.updateSemantics(update);
+
+  @override
+  ui.DisplayCornerRadii? get displayCornerRadii {
+    // Only Android API 31+ populates this; iOS and other platforms return null.
+    final profile = _controller.activeProfile;
+    if (profile.platform != DevicePlatform.android) {
+      return null;
+    }
+
+    final border = profile.screenBorder;
+    if (border is! CircularBorder) {
+      return null;
+    }
+
+    final physical = border.radius * devicePixelRatio;
+    return ui.DisplayCornerRadii(
+      topLeft: physical,
+      topRight: physical,
+      bottomRight: physical,
+      bottomLeft: physical,
+    );
+  }
 }
 
 /// Adapts a Flutter [EdgeInsets] to the [ui.ViewPadding] interface.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,13 +2,12 @@ name: flight_check
 description: >-
   A Flutter debug-mode tool for previewing your app against popular mobile
   device profiles while running on desktop.
-version: 1.1.0
-
+version: 1.2.0
 repository: https://github.com/devoncarew/flight_check
 
 environment:
   sdk: ^3.10.0
-  flutter: '>=3.38.0'
+  flutter: '>=3.44.0'
 
 dependencies:
   flutter:

--- a/test/binding/preview_flutter_view_test.dart
+++ b/test/binding/preview_flutter_view_test.dart
@@ -1,5 +1,6 @@
 import 'package:flight_check/src/binding/preview_flutter_view.dart';
 import 'package:flight_check/src/devices/device_database.dart';
+import 'package:flight_check/src/devices/screen_border.dart';
 import 'package:flight_check/src/preview_controller.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -87,5 +88,23 @@ void main() {
     expect(view.viewInsets.bottom, 0.0);
     expect(view.viewInsets.left, 0.0);
     expect(view.viewInsets.right, 0.0);
+  });
+
+  test('displayCornerRadii is null for iOS profiles', () {
+    controller.setProfile(DeviceDatabase.findById('iphone_15')!);
+    expect(view.displayCornerRadii, isNull);
+  });
+
+  test('displayCornerRadii returns physical-pixel radii for Android profiles', () {
+    final pixel = DeviceDatabase.findById('pixel_10')!;
+    controller.setProfile(pixel);
+    final radii = view.displayCornerRadii;
+    expect(radii, isNotNull);
+    final border = pixel.screenBorder as CircularBorder;
+    final expected = border.radius * view.devicePixelRatio;
+    expect(radii!.topLeft, closeTo(expected, 0.001));
+    expect(radii.topRight, closeTo(expected, 0.001));
+    expect(radii.bottomRight, closeTo(expected, 0.001));
+    expect(radii.bottomLeft, closeTo(expected, 0.001));
   });
 }

--- a/test/binding/preview_flutter_view_test.dart
+++ b/test/binding/preview_flutter_view_test.dart
@@ -95,16 +95,19 @@ void main() {
     expect(view.displayCornerRadii, isNull);
   });
 
-  test('displayCornerRadii returns physical-pixel radii for Android profiles', () {
-    final pixel = DeviceDatabase.findById('pixel_10')!;
-    controller.setProfile(pixel);
-    final radii = view.displayCornerRadii;
-    expect(radii, isNotNull);
-    final border = pixel.screenBorder as CircularBorder;
-    final expected = border.radius * view.devicePixelRatio;
-    expect(radii!.topLeft, closeTo(expected, 0.001));
-    expect(radii.topRight, closeTo(expected, 0.001));
-    expect(radii.bottomRight, closeTo(expected, 0.001));
-    expect(radii.bottomLeft, closeTo(expected, 0.001));
-  });
+  test(
+    'displayCornerRadii returns physical-pixel radii for Android profiles',
+    () {
+      final pixel = DeviceDatabase.findById('pixel_10')!;
+      controller.setProfile(pixel);
+      final radii = view.displayCornerRadii;
+      expect(radii, isNotNull);
+      final border = pixel.screenBorder as CircularBorder;
+      final expected = border.radius * view.devicePixelRatio;
+      expect(radii!.topLeft, closeTo(expected, 0.001));
+      expect(radii.topRight, closeTo(expected, 0.001));
+      expect(radii.bottomRight, closeTo(expected, 0.001));
+      expect(radii.bottomLeft, closeTo(expected, 0.001));
+    },
+  );
 }


### PR DESCRIPTION
- Require Flutter 3.44.0.
- Implement `FlutterView.displayCornerRadii` to spoof Android corner radii. Returns physical-pixel radii derived from the active profile's `CircularBorder` radius; returns `null` for iOS profiles, matching Android API 31+ semantics.
- prep for publishing
